### PR TITLE
Add field for VeronaPy

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -189,7 +189,7 @@ struct _object {
 
     PyTypeObject *ob_type;
     // VeronaPy: Field used for tracking which region this objects is stored in.
-    // Bottom bits stolen for distinguishing types of region ptr. 
+    // Bottom bits stolen for distinguishing types of region ptr.
     Py_uintptr_t ob_region;
 };
 

--- a/Include/object.h
+++ b/Include/object.h
@@ -188,6 +188,9 @@ struct _object {
 #endif
 
     PyTypeObject *ob_type;
+    // VeronaPy: Field used for tracking which region this objects is stored in.
+    // Bottom bits stolen for distinguishing types of region ptr. 
+    Py_uintptr_t ob_region;
 };
 
 /* Cast argument to PyObject* type. */

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -780,8 +780,9 @@ def python_is_optimized():
             final_opt = opt
     return final_opt not in ('', '-O0', '-Og')
 
-
-_header = 'nP'
+# VeronaPy: Added the extra region pointer here.
+# The getobjects pointers will be removed later.
+_header = 'nPP'
 _align = '0n'
 if hasattr(sys, "getobjects"):
     _header = '2P' + _header


### PR DESCRIPTION
We need a field to represent the region and immutability in VeronaPy.  This commit adds that field, and updates the test harness to understand the change.

Future PRs will reduce the object header size down to an acceptable level.  This has been done to keep the changes initially simple.