### PR TITLE
Pyrona: Create `RegionObject` and `RegionMetadata` objects

### DIFF
--- a/Include/internal/pycore_regions.h
+++ b/Include/internal/pycore_regions.h
@@ -26,6 +26,9 @@ PyObject* _Py_InvariantTgtFailure(void);
 PyObject* _Py_EnableInvariant(void);
 #define Py_EnableInvariant() _Py_EnableInvariant()
 
+PyObject* _Py_ResetInvariant(void);
+#define Py_ResetInvariant() _Py_ResetInvariant()
+
 #ifdef NDEBUG
 #define _Py_VPYDBG(fmt, ...)
 #define _Py_VPYDBGPRINT(fmt, ...)

--- a/Include/internal/pycore_regions.h
+++ b/Include/internal/pycore_regions.h
@@ -14,6 +14,15 @@ extern "C" {
 #define Py_CHECKWRITE(op) ((op) && _PyObject_CAST(op)->ob_region != _Py_IMMUTABLE)
 #define Py_REQUIREWRITE(op, msg) {if (Py_CHECKWRITE(op)) { _PyObject_ASSERT_FAILED_MSG(op, msg); }}
 
+/* This makes the given objects and all object reachable from the given
+ * object immutable. This will also move the objects into the immutable
+ * region.
+ *
+ * The argument is borrowed, meaning that it expects the calling context
+ * to handle the reference count.
+ *
+ * The function will return `Py_None` by default.
+ */
 PyObject* _Py_MakeImmutable(PyObject* obj);
 #define Py_MakeImmutable(op) _Py_MakeImmutable(_PyObject_CAST(op))
 

--- a/Include/object.h
+++ b/Include/object.h
@@ -275,6 +275,12 @@ static inline Py_ALWAYS_INLINE int _Py_IsImmutable(PyObject *op)
 }
 #define _Py_IsImmutable(op) _Py_IsImmutable(_PyObject_CAST(op))
 
+static inline Py_ALWAYS_INLINE int _Py_IsLocal(PyObject *op)
+{
+    return op->ob_region == _Py_DEFAULT_REGION;
+}
+#define _Py_IsLocal(op) _Py_IsLocal(_PyObject_CAST(op))
+
 
 static inline void Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt) {
     // This immortal check is for code that is unaware of immortal objects.

--- a/Include/object.h
+++ b/Include/object.h
@@ -314,6 +314,13 @@ static inline void Py_SET_REGION(PyObject *ob, Py_uintptr_t region) {
 #  define Py_SET_REGION(ob, region) Py_SET_REGION(_PyObject_CAST(ob), (region))
 #endif
 
+static inline Py_uintptr_t Py_GET_REGION(PyObject *ob) {
+    return ob->ob_region;
+}
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  define Py_GET_REGION(ob) Py_GET_REGION(_PyObject_CAST(ob))
+#endif
+
 
 /*
 Type objects contain a string containing the type name (to help somewhat

--- a/Lib/test/test_veronapy.py
+++ b/Lib/test/test_veronapy.py
@@ -389,6 +389,58 @@ class TestWeakRef(unittest.TestCase):
         # self.assertTrue(c.val() is obj)
         self.assertIsNone(c.val())
 
+class TestRegionOwnership(unittest.TestCase):
+    class A:
+        pass
+
+    def test_default_ownership(self):
+        a = self.A()
+        r = Region()
+        self.assertFalse(r.owns_object(a))
+
+    def test_add_ownership(self):
+        a = self.A()
+        r = Region()
+        r.add_object(a)
+        self.assertTrue(r.owns_object(a))
+
+    def test_remove_ownership(self):
+        a = self.A()
+        r = Region()
+        r.add_object(a)
+        r.remove_object(a)
+        self.assertFalse(r.owns_object(a))
+
+    def test_add_ownership2(self):
+        a = self.A()
+        r1 = Region()
+        r2 = Region()
+        r1.add_object(a)
+        self.assertFalse(r2.owns_object(a))
+
+    def test_should_fail_add_ownership_twice_1(self):
+        a = self.A()
+        r = Region()
+        r.add_object(a)
+        try:
+            r.add_object(a)
+        except RuntimeError:
+            pass
+        else:
+            self.fail("Should not reach here")
+
+    def test_should_fail_add_ownership_twice_2(self):
+        a = self.A()
+        r = Region()
+        r.add_object(a)
+        try:
+            r2 = Region()
+            r2.add_object(a)
+        except RuntimeError:
+            pass
+        else:
+            self.fail("Should not reach here")
+
 # This test will make the Python environment unusable.
 # Should perhaps forbid making the frame immutable.
 # class TestStackCapture(unittest.TestCase):

--- a/Lib/test/test_veronapy.py
+++ b/Lib/test/test_veronapy.py
@@ -474,8 +474,10 @@ class TestRegionInvariance(unittest.TestCase):
 
         # Create a region and take ownership of a
         r = Region()
+        # FIXME: Once the write barrier is implemented, this assert will fail.
+        # The code above should work without any errors.
         self.assertRaises(RuntimeError, r.add_object, a)
-        
+
         # Check that the errors are on the appropriate objects
         self.assertFalse(r.owns_object(b))
         self.assertTrue(r.owns_object(a))
@@ -493,31 +495,6 @@ class TestRegionInvariance(unittest.TestCase):
         r.add_object(a)
         self.assertFalse(r.owns_object(b))
         self.assertTrue(r.owns_object(a))
-
-    def disabled_test_allow_bridge_object_ref(self):
-        r1 = Region()
-        r1a = self.A()
-        r1.add_object(r1a)
-        r2 = Region()
-        r2a = self.A()
-        r2.add_object(r2a)
-
-        # Make r2 a subregion of r1
-        r1a.f = r2
-        try:
-            # Create a beautiful cycle
-            r2a.f = r1
-        except RuntimeError:
-            # These are currently true since the write barrier doesn't exist
-            # and the exception is thrown by the invariance check
-            if invariant_failure_src() == a:
-                self.assertEqual(invariant_failure_tgt(), b)
-            elif invariant_failure_tgt() == a:
-                self.assertEqual(invariant_failure_src(), b)
-            else:
-                self.fail("Should not reach here")
-        else:
-            self.fail("Should not reach here")
 
     def test_should_fail_external_uniqueness(self):
         a = self.A()

--- a/Lib/test/test_veronapy.py
+++ b/Lib/test/test_veronapy.py
@@ -393,6 +393,10 @@ class TestRegionOwnership(unittest.TestCase):
     class A:
         pass
 
+    def setUp(self):
+        # This freezes A and super and meta types of A namely `type` and `object`
+        makeimmutable(self.A)
+
     def test_default_ownership(self):
         a = self.A()
         r = Region()

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2041,7 +2041,7 @@ extern PyTypeObject _PyMemoryIter_Type;
 extern PyTypeObject _PyLineIterator;
 extern PyTypeObject _PyPositionsIterator;
 extern PyTypeObject _PyLegacyEventHandler_Type;
-extern PyTypeObject Region_Type;
+extern PyTypeObject PyRegion_Type;
 
 static PyTypeObject* static_types[] = {
     // The two most important base types: must be initialized first and
@@ -2164,7 +2164,7 @@ static PyTypeObject* static_types[] = {
     &PyODict_Type,        // base=&PyDict_Type
 
     // Pyrona Region:
-    &Region_Type,
+    &PyRegion_Type,
 };
 
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2041,6 +2041,7 @@ extern PyTypeObject _PyMemoryIter_Type;
 extern PyTypeObject _PyLineIterator;
 extern PyTypeObject _PyPositionsIterator;
 extern PyTypeObject _PyLegacyEventHandler_Type;
+extern PyTypeObject Region_Type;
 
 static PyTypeObject* static_types[] = {
     // The two most important base types: must be initialized first and
@@ -2161,6 +2162,9 @@ static PyTypeObject* static_types[] = {
     &PyODictKeys_Type,    // base=&PyDictKeys_Type
     &PyODictValues_Type,  // base=&PyDictValues_Type
     &PyODict_Type,        // base=&PyDict_Type
+
+    // Pyrona Region:
+    &Region_Type,
 };
 
 

--- a/Objects/regions.c
+++ b/Objects/regions.c
@@ -677,7 +677,7 @@ next:
     stack_free(frontier);
 
 
-    return obj;
+    Py_RETURN_NONE;
 }
 
 bool is_bridge_object(PyObject *op) {
@@ -801,7 +801,7 @@ static int PyRegion_init(PyRegionObject *self, PyObject *args, PyObject *kwds) {
         return -1;
     if (self->name) {
         Py_XINCREF(self->name);
-        // Freeze the name and it's type. Short strings in python are inturned
+        // Freeze the name and it's type. Short strings in Python are interned
         // by default. This means that `id("AB") == id("AB")`. We therefore
         // need to either clone the name object or freeze it to share it
         // across regions. Freezing should be safe, since `+=` and other

--- a/Objects/regions.c
+++ b/Objects/regions.c
@@ -238,7 +238,7 @@ int _Py_CheckRegionInvariant(PyThreadState *tstate)
             // Also need to visit the type of the object
             // As this isn't covered by the traverse.
             PyObject* type_op = PyObject_Type(op);
-            visit_invariant_check(op, type_op);
+            visit_invariant_check(type_op, op);
             Py_DECREF(type_op);
 
             // If we detected an error, stop so we don't
@@ -733,6 +733,8 @@ static void Region_dealloc(PyRegionObject *self) {
 }
 
 static int Region_init(PyRegionObject *self, PyObject *args, PyObject *kwds) {
+    notify_regions_in_use();
+
     static char *kwlist[] = {"name", NULL};
     self->metadata = (regionmetadata*)calloc(1, sizeof(regionmetadata));
     self->metadata->bridge = self;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2814,7 +2814,6 @@ builtin_enableinvariant_impl(PyObject *module)
     return Py_EnableInvariant();
 }
 
-
 typedef struct {
     PyObject_HEAD
     Py_ssize_t tuplesize;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -3163,7 +3163,7 @@ static struct PyModuleDef builtinsmodule = {
     NULL
 };
 
-extern PyTypeObject Region_Type;
+extern PyTypeObject PyRegion_Type;
 PyObject *
 _PyBuiltin_Init(PyInterpreterState *interp)
 {
@@ -3224,7 +3224,7 @@ _PyBuiltin_Init(PyInterpreterState *interp)
     SETBUILTIN("tuple",                 &PyTuple_Type);
     SETBUILTIN("type",                  &PyType_Type);
     SETBUILTIN("zip",                   &PyZip_Type);
-    SETBUILTIN("Region",                &Region_Type);
+    SETBUILTIN("Region",                &PyRegion_Type);
 
     debug = PyBool_FromLong(config->optimization_level == 0);
     if (PyDict_SetItemString(dict, "__debug__", debug) < 0) {

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -3163,6 +3163,7 @@ static struct PyModuleDef builtinsmodule = {
 };
 
 extern PyTypeObject PyRegion_Type;
+
 PyObject *
 _PyBuiltin_Init(PyInterpreterState *interp)
 {

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -3163,7 +3163,7 @@ static struct PyModuleDef builtinsmodule = {
     NULL
 };
 
-
+extern PyTypeObject Region_Type;
 PyObject *
 _PyBuiltin_Init(PyInterpreterState *interp)
 {
@@ -3224,6 +3224,8 @@ _PyBuiltin_Init(PyInterpreterState *interp)
     SETBUILTIN("tuple",                 &PyTuple_Type);
     SETBUILTIN("type",                  &PyType_Type);
     SETBUILTIN("zip",                   &PyZip_Type);
+    SETBUILTIN("Region",                &Region_Type);
+
     debug = PyBool_FromLong(config->optimization_level == 0);
     if (PyDict_SetItemString(dict, "__debug__", debug) < 0) {
         Py_DECREF(debug);


### PR DESCRIPTION
### TODO list:

* [x] Memory leak since we don't decref the internal dictionary. Decref causes seg fault
* [x] Segfault when passing a non string object as the name

cc: @TobiasWrigstad 