### PR TITLE
Make _Py_NewReference reset the region to local

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -177,7 +177,6 @@ _PyObject_Init(PyObject *op, PyTypeObject *typeobj)
 {
     assert(op != NULL);
     Py_SET_TYPE(op, typeobj);
-    Py_SET_REGION(op, _Py_LOCAL_REGION);
     if (_PyType_HasFeature(typeobj, Py_TPFLAGS_HEAPTYPE)) {
         Py_INCREF(typeobj);
     }

--- a/Lib/test/test_veronapy.py
+++ b/Lib/test/test_veronapy.py
@@ -547,5 +547,18 @@ class TestGlobalDictMutation(unittest.TestCase):
         self.assertTrue(isimmutable(f1))
         self.assertRaises(NotWriteableError, f1)
 
+class TestPoolAllocation(unittest.TestCase):
+    # If pooling does not reset region between allocations,
+    # then the second call to f will result in `a` being owned by
+    # the first region that no has been deallocated.  This
+    # will result in a UAF that ASAN can detect.
+    def test_pool_allocation(self):
+        def f():
+            r = Region()
+            a = {}
+            r.add_object(a)
+        f()
+        f()
+
 if __name__ == '__main__':
     unittest.main()

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2233,6 +2233,7 @@ _Py_NewReference(PyObject *op)
     reftotal_increment(_PyInterpreterState_GET());
 #endif
     new_reference(op);
+    Py_SET_REGION(op, _Py_LOCAL_REGION);
 }
 
 void


### PR DESCRIPTION
Some pooling code does not call `_PyObject_Init`, so but instead just calls `_Py_NewReference`.  This is problematic for us as it means the region is not reset on reallocating from a Pool.
    
It appears from inspection that `_Py_NewReferenceNoTotal` is used in special cases that should keep the same region.
* Reallocation/Resize
* Reincarnation