### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build_min.yml
+++ b/.github/workflows/build_min.yml
@@ -134,7 +134,7 @@ jobs:
 
   check_generated_files:
     name: 'Check if generated files are up to date'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'


### PR DESCRIPTION
Github Actions has migrated to 24.04, but this is breaking some parts of CI.  Pin the version to 22.04, which is the working version.