### PR TITLE
Generic Attribute Issue

### DIFF
--- a/Lib/test/test_veronapy.py
+++ b/Lib/test/test_veronapy.py
@@ -560,5 +560,15 @@ class TestPoolAllocation(unittest.TestCase):
         f()
         f()
 
+class TestGenericAliasBug(unittest.TestCase):
+    # The code inside generic alias attempts to set
+    # __orig_class__ on the empty tuple, which is not
+    # allowed. The make immutable means this can fail
+    # NotWriteableError rather than the TypeError or 
+    # AttributeError that would be raised otherwise.
+    def test_generic_alias_bug(self):
+        c = makeimmutable(())
+        tuple[int]()
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_veronapy.py
+++ b/Lib/test/test_veronapy.py
@@ -564,7 +564,7 @@ class TestGenericAliasBug(unittest.TestCase):
     # The code inside generic alias attempts to set
     # __orig_class__ on the empty tuple, which is not
     # allowed. The make immutable means this can fail
-    # NotWriteableError rather than the TypeError or 
+    # NotWriteableError rather than the TypeError or
     # AttributeError that would be raised otherwise.
     def test_generic_alias_bug(self):
         c = makeimmutable(())

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -596,7 +596,8 @@ set_orig_class(PyObject *obj, PyObject *self)
     if (obj != NULL) {
         if (PyObject_SetAttr(obj, &_Py_ID(__orig_class__), self) < 0) {
             if (!PyErr_ExceptionMatches(PyExc_AttributeError) &&
-                !PyErr_ExceptionMatches(PyExc_TypeError))
+                !PyErr_ExceptionMatches(PyExc_TypeError) &&
+                !PyErr_ExceptionMatches(PyExc_NotWriteableError))
             {
                 Py_DECREF(obj);
                 return NULL;


### PR DESCRIPTION
The code inside generic alias attempts to set `__orig_class__` on the empty tuple, which is not
allowed. The make immutable means this can fail `NotWriteableError` rather than the `TypeError` or 
`AttributeError` that would be raised otherwise
