### PR TITLE
Make all the core library globally allocated objects immutable

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -28,7 +28,7 @@ extern "C" {
         _PyObject_EXTRA_INIT                                  \
         .ob_refcnt = _Py_IMMORTAL_REFCNT,                     \
         .ob_type = (type),                                    \
-        .ob_region = (Py_region_ptr_with_tags_t){_Py_LOCAL_REGION} \
+        .ob_region = (Py_region_ptr_with_tags_t){_Py_IMMUTABLE} \
     },
 #define _PyVarObject_HEAD_INIT(type, size)    \
     {                                         \

--- a/Include/object.h
+++ b/Include/object.h
@@ -153,7 +153,7 @@ static inline Py_region_ptr_with_tags_t Py_region_ptr_with_tags(Py_region_ptr_t 
         _PyObject_EXTRA_INIT                     \
         { _Py_IMMORTAL_REFCNT },                 \
         (type),                                  \
-        (Py_region_ptr_with_tags_t){_Py_LOCAL_REGION} \
+        (Py_region_ptr_with_tags_t){_Py_IMMUTABLE} \
     },
 #else
 #define PyObject_HEAD_INIT(type)                 \

--- a/Lib/test/test_capi/test_abstract.py
+++ b/Lib/test/test_capi/test_abstract.py
@@ -116,7 +116,7 @@ class CAPITest(unittest.TestCase):
         self.assertRaises(RuntimeError, xsetattr, obj, 'evil', NULL)
 
         self.assertRaises(RuntimeError, xsetattr, obj, 'evil', 'good')
-        self.assertRaises(AttributeError, xsetattr, 42, 'a', 5)
+        self.assertRaises(NotWriteableError, xsetattr, 42, 'a', 5)
         self.assertRaises(TypeError, xsetattr, obj, 1, 5)
         # CRASHES xsetattr(obj, NULL, 5)
         # CRASHES xsetattr(NULL, 'a', 5)
@@ -136,7 +136,7 @@ class CAPITest(unittest.TestCase):
         self.assertRaises(RuntimeError, setattrstring, obj, b'evil', NULL)
 
         self.assertRaises(RuntimeError, setattrstring, obj, b'evil', 'good')
-        self.assertRaises(AttributeError, setattrstring, 42, b'a', 5)
+        self.assertRaises(NotWriteableError, setattrstring, 42, b'a', 5)
         self.assertRaises(TypeError, setattrstring, obj, 1, 5)
         self.assertRaises(UnicodeDecodeError, setattrstring, obj, b'\xff', 5)
         # CRASHES setattrstring(obj, NULL, 5)
@@ -153,7 +153,7 @@ class CAPITest(unittest.TestCase):
         xdelattr(obj, '\U0001f40d')
         self.assertFalse(hasattr(obj, '\U0001f40d'))
 
-        self.assertRaises(AttributeError, xdelattr, 42, 'numerator')
+        self.assertRaises(NotWriteableError, xdelattr, 42, 'numerator')
         self.assertRaises(RuntimeError, xdelattr, obj, 'evil')
         self.assertRaises(TypeError, xdelattr, obj, 1)
         # CRASHES xdelattr(obj, NULL)
@@ -170,7 +170,7 @@ class CAPITest(unittest.TestCase):
         delattrstring(obj, '\U0001f40d'.encode())
         self.assertFalse(hasattr(obj, '\U0001f40d'))
 
-        self.assertRaises(AttributeError, delattrstring, 42, b'numerator')
+        self.assertRaises(NotWriteableError, delattrstring, 42, b'numerator')
         self.assertRaises(RuntimeError, delattrstring, obj, b'evil')
         self.assertRaises(UnicodeDecodeError, delattrstring, obj, b'\xff')
         # CRASHES delattrstring(obj, NULL)
@@ -297,7 +297,7 @@ class CAPITest(unittest.TestCase):
         self.assertRaises(SystemError, setitem, {}, 'a', NULL)
         self.assertRaises(IndexError, setitem, [], 1, 5)
         self.assertRaises(TypeError, setitem, [], 'a', 5)
-        self.assertRaises(TypeError, setitem, (), 1, 5)
+        self.assertRaises(NotWriteableError, setitem, (), 1, 5)
         self.assertRaises(SystemError, setitem, NULL, 'a', 5)
 
     def test_mapping_setitemstring(self):

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1076,7 +1076,7 @@ order (MRO) for bases """
 
         class MyInt(int):
             __slots__ = ()
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NotWriteableError):
             (1).__class__ = MyInt
 
         class MyFloat(float):
@@ -1091,17 +1091,17 @@ order (MRO) for bases """
 
         class MyStr(str):
             __slots__ = ()
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NotWriteableError):
             "a".__class__ = MyStr
 
         class MyBytes(bytes):
             __slots__ = ()
-        with self.assertRaises(TypeError):
+        with self.assertRaises((TypeError, NotWriteableError)):
             b"a".__class__ = MyBytes
 
         class MyTuple(tuple):
             __slots__ = ()
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NotWriteableError):
             ().__class__ = MyTuple
 
         class MyFrozenSet(frozenset):
@@ -4082,7 +4082,7 @@ order (MRO) for bases """
 
         try:
             list.__bases__ = (dict,)
-        except TypeError:
+        except NotWriteableError:
             pass
         else:
             self.fail("shouldn't be able to assign to list.__bases__")

--- a/Lib/test/test_type_aliases.py
+++ b/Lib/test/test_type_aliases.py
@@ -232,7 +232,7 @@ class TypeAliasConstructorTest(unittest.TestCase):
 
 class TypeAliasTypeTest(unittest.TestCase):
     def test_immutable(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NotWriteableError):
             TypeAliasType.whatever = "not allowed"
 
     def test_no_subclassing(self):

--- a/Lib/test/test_type_annotations.py
+++ b/Lib/test/test_type_annotations.py
@@ -32,9 +32,9 @@ class TypeAnnotationTests(unittest.TestCase):
         # builtin types don't have __annotations__ (yet!)
         with self.assertRaises(AttributeError):
             print(float.__annotations__)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NotWriteableError):
             float.__annotations__ = {}
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NotWriteableError):
             del float.__annotations__
 
         # double delete

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2388,7 +2388,7 @@ def no_type_check(arg):
                 no_type_check(obj)
     try:
         arg.__no_type_check__ = True
-    except TypeError:  # built-in classes
+    except NotWriteableError:  # built-in classes
         pass
     return arg
 
@@ -2507,7 +2507,7 @@ def final(f):
     """
     try:
         f.__final__ = True
-    except (AttributeError, TypeError):
+    except (AttributeError, TypeError, NotWriteableError):
         # Skip the attribute silently if it is not writable.
         # AttributeError happens if the object has __slots__ or a
         # read-only property, TypeError if it's a builtin class.

--- a/Lib/unittest/suite.py
+++ b/Lib/unittest/suite.py
@@ -152,7 +152,7 @@ class TestSuite(BaseTestSuite):
         failed = False
         try:
             currentClass._classSetupFailed = False
-        except TypeError:
+        except NotWriteableError:
             # test may actually be a function
             # so its class will be a builtin-type
             pass


### PR DESCRIPTION
The core library bakes a bunch of objects in, such as types and small integers. This makes all the things that are baked in Immutable using the immutable region.  I am not sure if this is the right thing to do.  @matajoh had previously made some of the types immutable like this, but not in as extreme a way.  The earlier version didn't satisfy the invariant that Immutable can only reach immutable.  I believe this more aggressive version will satisfy the invariant.
