### PR TITLE
Phase3: Let's close some regions :D (`try_close()`)

### DIFF
--- a/Lib/test/test_using.py
+++ b/Lib/test/test_using.py
@@ -81,9 +81,9 @@ class UsingTest(unittest.TestCase):
         r.open()
         self.assertTrue(r.is_open())
         c = Cown(r)
+        r = None
         self.assertTrue(self.hacky_state_check(c, "pending-release"))
-        r.close()
-        self.assertFalse(r.is_open())
+        c.get().close()
         self.assertTrue(self.hacky_state_check(c, "released"))
 
     def test_acquire(self):
@@ -94,9 +94,9 @@ class UsingTest(unittest.TestCase):
             r = c.get()
             r.open()
             self.assertTrue(self.hacky_state_check(c, "acquired"))
-            r.close()
+            r = None
+            c.get().close()
             self.assertTrue(self.hacky_state_check(c, "released"))
-            self.assertFalse(r.is_open())
         self.assertTrue(self.hacky_state_check(c, "released"))
 
     def test_region_cown_ptr(self):

--- a/Lib/test/test_veronapy.py
+++ b/Lib/test/test_veronapy.py
@@ -522,6 +522,25 @@ class TestRegionOwnership(unittest.TestCase):
         else:
             self.fail("Should not reach here -- a can't be owned by two objects")
 
+class TestTryCloseRegion(unittest.TestCase):
+    class A:
+        pass
+
+    def setUp(self):
+        # This freezes A and super and meta types of A namely `type` and `object`
+        makeimmutable(self.A)
+        # FIXME: remove this line when the write barrier works
+        makeimmutable(type({}))
+
+    def test_try_close_fail(self):
+        a = self.A()
+        r1 = Region("r1")
+        
+        # This creates a reference into the region
+        r1.a = a
+        self.assertFalse(r1.try_close())
+
+
 # This test will make the Python environment unusable.
 # Should perhaps forbid making the frame immutable.
 # class TestStackCapture(unittest.TestCase):

--- a/Objects/cown.c
+++ b/Objects/cown.c
@@ -170,7 +170,7 @@ int _PyCown_is_released(PyObject *self) {
 // The ignored argument is required for this function's type to be
 // compatible with PyCFunction
 static PyObject *PyCown_get(PyCownObject *self, PyObject *ignored) {
-    BAIL_UNLESS_ACQUIRED(self, "Attempt to get value of unacquired cown");
+    BAIL_UNLESS_OWNED(self, "Attempt to get value of unacquired cown");
 
     if (self->value) {
         return Py_NewRef(self->value);


### PR DESCRIPTION
This adds the new `try_close()` function which *cleans* the LRC and OSC to see if the region can be closed. It returns `True` if the close was successful `False` otherwise.

The implementation roughly looks like this:
1. Merge the region into the local region
2. Move all objects reachable from the bridge object back into the region
3. Do the same for any sub-regions

Finally, check the LRC. It's expected to be 1 from the region being passed in as a function argument. Or 2 if the owning reference comes from the local region.

---

Additional changes:
* `Cown`s in the `pending-release` state now allow access to their region (to allow) closing it (cc @TobiasWrigstad ) 
* Added a `is_dirty` flag to `regionmetadata`. Currently, it's always false, but I already inserted some checks and *is clean* notifications for the future.