### PR TITLE
Phase3: Add write barrier to `Cell` and some bytecodes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,7 +299,7 @@ jobs:
 
   build_ubuntu:
     name: 'Ubuntu'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
@@ -366,7 +366,7 @@ jobs:
 
   build_ubuntu_ssltests:
     name: 'Ubuntu SSL tests with OpenSSL'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
@@ -420,7 +420,7 @@ jobs:
 
   test_hypothesis:
     name: "Hypothesis tests on Ubuntu"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true' && needs.check_source.outputs.run_hypothesis == 'true'
@@ -529,7 +529,7 @@ jobs:
 
   build_asan:
     name: 'Address sanitizer'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'

--- a/.github/workflows/build_min.yml
+++ b/.github/workflows/build_min.yml
@@ -286,7 +286,7 @@ jobs:
 
   build_ubuntu:
     name: 'Ubuntu'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
@@ -356,7 +356,7 @@ jobs:
   #
   # build_ubuntu_ssltests:
   #   name: 'Ubuntu SSL tests with OpenSSL'
-  #   runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-22.04
   #   timeout-minutes: 60
   #   needs: check_source
   #   if: needs.check_source.outputs.run_tests == 'true'
@@ -410,7 +410,7 @@ jobs:
 
   test_hypothesis:
     name: "Hypothesis tests on Ubuntu"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true' && needs.check_source.outputs.run_hypothesis == 'true'
@@ -520,7 +520,7 @@ jobs:
 
   build_asan:
     name: 'Address sanitizer'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'

--- a/Include/internal/pycore_regions.h
+++ b/Include/internal/pycore_regions.h
@@ -58,10 +58,10 @@ PyObject* _Py_ResetInvariant(void);
 
 // Invariant placeholder
 bool _Py_RegionAddReference(PyObject* src, PyObject* new_tgt);
-#define Py_REGIONADDREFERENCE(a, b) _Py_RegionAddReference(_PyObject_CAST(a), b)
+#define Py_REGIONADDREFERENCE(a, b) _Py_RegionAddReference(_PyObject_CAST(a), _PyObject_CAST(b))
 
 void _Py_RegionAddLocalReference(PyObject* new_tgt);
-#define Py_REGIONADDLOCALREFERENCE(b) _Py_RegionAddLocalReference(b)
+#define Py_REGIONADDLOCALREFERENCE(b) _Py_RegionAddLocalReference(_PyObject_CAST(b))
 
 // Helper macros to count the number of arguments
 #define _COUNT_ARGS(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, N, ...) N
@@ -70,8 +70,11 @@ void _Py_RegionAddLocalReference(PyObject* new_tgt);
 bool _Py_RegionAddReferences(PyObject* src, int new_tgtc, ...);
 #define Py_REGIONADDREFERENCES(a, ...) _Py_RegionAddReferences(_PyObject_CAST(a), COUNT_ARGS(__VA_ARGS__), __VA_ARGS__)
 
+bool _Py_RegionChangeReference(PyObject* src, PyObject* old_tgt, PyObject* new_tgt);
+#define Py_REGIONCHANGEREFERENCE(a, b, c) _Py_RegionChangeReference(_PyObject_CAST(a), _PyObject_CAST(b), _PyObject_CAST(c))
+
 void _Py_RegionRemoveReference(PyObject* src, PyObject* old_tgt);
-#define Py_REGIONREMOVEREFERENCE(a, b) _Py_RegionRemoveReference(_PyObject_CAST(a), b)
+#define Py_REGIONREMOVEREFERENCE(a, b) _Py_RegionRemoveReference(_PyObject_CAST(a), _PyObject_CAST(b))
 
 #ifdef NDEBUG
 #define _Py_VPYDBG(fmt, ...)

--- a/Include/internal/pycore_regions.h
+++ b/Include/internal/pycore_regions.h
@@ -100,8 +100,8 @@ int _PyRegion_is_closed(PyObject* op);
 #ifdef _Py_TYPEOF
 #define Py_CLEAR_OBJECT_FIELD(op, field) \
     do { \
-        _Py_TYPEOF(op)* _tmp_field_ptr = &(field); \
-        _Py_TYPEOF(op) _tmp_old_field = (*_tmp_field_ptr); \
+        _Py_TYPEOF(field)* _tmp_field_ptr = &(field); \
+        _Py_TYPEOF(field) _tmp_old_field = (*_tmp_field_ptr); \
         if (_tmp_old_field != NULL) { \
             *_tmp_field_ptr = _Py_NULL; \
             Py_REGIONREMOVEREFERENCE(op, _tmp_old_field); \

--- a/Lib/test/test_veronapy_writebarrier.py
+++ b/Lib/test/test_veronapy_writebarrier.py
@@ -1,0 +1,78 @@
+import unittest
+import dis
+
+class TestCellWriteBarrier(unittest.TestCase):
+    class A:
+        pass
+
+    # Create a cell by capturing a variable in a closure
+    # The content of the cell is an instance of A which can be added to regions.
+    def make_cell(self):
+        x = self.A()
+        return (lambda: x).__closure__[0]
+
+    def setUp(self):
+        # This freezes A and super and meta types of A namely `type` and `object`
+        makeimmutable(self.A)
+
+    def test_cell_region_propagates(self):
+        c = self.make_cell()
+        r = Region()
+
+        # Move c into the region r
+        r.c = c
+
+        # Make sure region r now owns the cell and its content
+        self.assertTrue(r.owns_object(c))
+        self.assertTrue(r.owns_object(c.cell_contents))
+
+    def test_cell_add_ref(self):
+        c = self.make_cell()
+        r = Region()
+
+        # Move c into the region r
+        r.c = c
+
+        # Make sure region r takes ownership of new references from c
+        self.assertTrue(r.owns_object(c))
+        self.assertTrue(r.owns_object(c.cell_contents))
+
+    def test_cell_remove_ref(self):
+        c = self.make_cell()
+        r1 = Region()
+        child = Region()
+
+        # Move c into the region r1
+        r1.c = c
+        self.assertTrue(r1.owns_object(c))
+
+        # Make `child` a subregion of `r1`
+        c.cell_contents = child
+        self.assertEqual(c.cell_contents, child)
+
+        # Replaceing the value in `c` should unparent the child region
+        # We can test this by reparenting it to `r2` without an exception
+        r2 = Region()
+        c.cell_contents = None
+        r2.child = child
+
+    def test_cell_replace_same_bridge(self):
+        # This test makes sure that reassigning a pointer to a bridge object with
+        # the same value doesn't throw an exception, due the write barrier
+        # believing that there are two owning references to the same bridge object.
+        c = self.make_cell()
+        r = Region()
+        child = Region()
+
+        # Move c into the region r
+        r.c = c
+        self.assertTrue(r.owns_object(c))
+
+        # Make `child` a subregion of `r1`
+        c.cell_contents = child
+        self.assertEqual(c.cell_contents, child)
+
+        # Reassigning the owning pointer to the bridge should be fine
+        # since this writes replaces the previous owning reference
+        c.cell_contents = child
+

--- a/Lib/test/test_veronapy_writebarrier.py
+++ b/Lib/test/test_veronapy_writebarrier.py
@@ -76,3 +76,163 @@ class TestCellWriteBarrier(unittest.TestCase):
         # since this writes replaces the previous owning reference
         c.cell_contents = child
 
+# It's not possible to test the existance of all bytecodes. The dis only
+# shows the unoptimized version of the bytecode. For testing specilized or
+# optimized it's therefore not possible to check for the presence of that
+# bytecode in the `dis`. Instead we can only check for the effects of the
+# bytecodes.
+#
+# During test development it's also possible to verify that the expected
+# bytecode is triggered by setting a breakpoint in it. Note that it's also
+# run during the startup of the runtime and by other tests, so make sure
+# the test in question actually started, when the breakpoint is triggered.
+class TestBytecodeWriteBarrier(unittest.TestCase):
+    # Define a class with __slots__
+    class ClassWithSlots:
+        # Use `__slots__` to get the `STORE_ATTR_SLOT` bytecode
+        __slots__ = ('slot',)
+
+        def __init__(self):
+            self.slot = None
+
+    class ClassWithAttr:
+        def __init__(self):
+            self.attr = None
+
+    def setUp(self):
+        # This freezes A and super and meta types of A namely `type` and `object`
+        makeimmutable(self.ClassWithSlots)
+        makeimmutable(self.ClassWithAttr)
+
+    def test_delete_deref(self):
+        r = Region()
+        r.field = {}
+        x = r.field
+
+        # Make sure the region knows about local reference from x
+        self.assertFalse(r.try_close())
+
+        def del_x():
+            nonlocal x
+            del x # This triggers the DELETE_DEREF opcode
+
+        # Create the function and disassemble to confirm DELETE_DEREF is present
+        bytecode = dis.Bytecode(del_x)
+        self.assertIn("DELETE_DEREF", [instr.opname for instr in bytecode])
+
+        self.assertTrue(r.is_open())
+
+        # Call the function forcing the deletion of x which should
+        # close the region.
+        del_x()
+
+        self.assertFalse(r.is_open())
+
+    # This tests that references stored by `STORE_ATTR_SLOT` are known
+    # by the write barrier
+    def test_store_attr_slot_add_reference(self):
+        def set_value(obj, val):
+            obj.slot = val  # This triggers the STORE_ATTR_SLOT opcode
+
+        # Setup a region and a class with slots
+        r = Region()
+        r.slots = self.ClassWithSlots()
+        self.assertTrue(r.owns_object(r.slots))
+
+        # Run `set_value` multiple times to optimize it
+        set_value(r.slots, None)
+        set_value(r.slots, {})
+
+        # Create a new local object
+        new_object = {}
+        new_object["data"] = {}
+
+        # Store the object in slots
+        set_value(r.slots, new_object)
+
+        # Verify the region ownership
+        self.assertTrue(r.owns_object(new_object))
+        self.assertTrue(r.owns_object(new_object["data"]))
+
+    # This tests that references removed by `STORE_ATTR_SLOT` are known
+    # by the write barrier
+    def test_store_attr_slot_remove_reference(self):
+        def set_value(obj, val):
+            obj.slot = val  # This triggers the STORE_ATTR_SLOT opcode
+
+        # Setup a region and a class with slots
+        r = Region()
+        r.data = {}
+        slots = self.ClassWithSlots()
+
+        # Run `set_value` multiple times to optimize it
+        set_value(slots, None)
+        set_value(slots, {})
+
+        # Create local reference into the region
+        set_value(slots, r.data)
+
+        # Make sure the region knows about the reference from the slot
+        self.assertFalse(r.try_close())
+
+        # Clear the reference from slots
+        set_value(slots, None)
+
+        # Check that the region was closed.
+        self.assertFalse(r.is_open())
+
+    # This tests that references stored by `STORE_ATTR_INSTANCE_VALUE` are known
+    # by the write barrier
+    def test_store_attr_instance_value_add_reference(self):
+        def set_value(obj, val):
+            obj.attr = val  # This triggers the STORE_ATTR_INSTANCE_VALUE opcode
+
+        # Setup a region and a class with attributes
+        r = Region()
+        r.attr = self.ClassWithAttr()
+        self.assertTrue(r.owns_object(r.attr))
+
+        # Run `set_value` multiple times to optimize it
+        set_value(r.attr, None)
+        set_value(r.attr, {})
+
+        # Create a new local object
+        new_object = {}
+        new_object["data"] = {}
+
+        # Store the object in attributes
+        set_value(r.attr, new_object)
+
+        # Verify the region ownership
+        self.assertTrue(r.owns_object(new_object))
+        self.assertTrue(r.owns_object(new_object["data"]))
+
+    # This tests that references removed by `STORE_ATTR_INSTANCE_VALUE` are known
+    # by the write barrier
+    def test_store_attr_instance_value_remove_reference(self):
+        def set_value(obj, val):
+            obj.attr = val  # This triggers the STORE_ATTR_INSTANCE_VALUE opcode
+
+        # Setup a region and a class with attributes
+        r = Region()
+        r.data = {}
+        attr = self.ClassWithAttr()
+
+        # Run `set_value` multiple times to optimize it
+        set_value(attr, None)
+        set_value(attr, {})
+
+        # Create local reference into the region
+        set_value(attr, r.data)
+
+        # Make sure the region knows about the reference from the slot
+        self.assertFalse(r.try_close())
+
+        # Clear the reference from attributes
+        set_value(attr, None)
+
+        # Check that the region was closed.
+        self.assertFalse(r.is_open())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Objects/cellobject.c
+++ b/Objects/cellobject.c
@@ -140,8 +140,7 @@ cell_clear(PyCellObject *op)
         return -1;
     }
 
-    Py_REGIONREMOVEREFERENCE(op, op->ob_ref);
-    Py_CLEAR(op->ob_ref);
+    Py_CLEAR_OBJECT_FIELD(op, op->ob_ref);
     return 0;
 }
 

--- a/Objects/cellobject.c
+++ b/Objects/cellobject.c
@@ -74,6 +74,13 @@ PyCell_Set(PyObject *op, PyObject *value)
     }
 
     PyObject *old_value = PyCell_GET(op);
+
+    // Check that the reference can be created
+    if (!Py_REGIONCHANGEREFERENCE(op, old_value, value)) {
+        // Propagate the error from attempting to add the reference
+        return -1;
+    }
+
     PyCell_SET(op, Py_XNewRef(value));
     Py_XDECREF(old_value);
     return 0;
@@ -133,6 +140,7 @@ cell_clear(PyCellObject *op)
         return -1;
     }
 
+    Py_REGIONREMOVEREFERENCE(op, op->ob_ref);
     Py_CLEAR(op->ob_ref);
     return 0;
 }
@@ -153,6 +161,14 @@ cell_set_contents(PyCellObject *op, PyObject *obj, void *Py_UNUSED(ignored))
 {
     if(!Py_CHECKWRITE(op)){
         PyErr_WriteToImmutable(op);
+        return -1;
+    }
+
+    PyObject *old_value = PyCell_GET(op);
+
+    // Check that the reference can be created
+    if (!Py_REGIONCHANGEREFERENCE(op, old_value, obj)) {
+        // Propagate the error from attempting to add the reference
         return -1;
     }
 
@@ -186,7 +202,7 @@ PyTypeObject PyCell_Type = {
     PyObject_GenericGetAttr,                    /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_REGION_AWARE,    /* tp_flags */
     cell_new_doc,                               /* tp_doc */
     (traverseproc)cell_traverse,                /* tp_traverse */
     (inquiry)cell_clear,                        /* tp_clear */

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1433,6 +1433,17 @@ _PyFrame_LocalsToFast(_PyInterpreterFrame *frame, int clear)
         if (cell != NULL) {
             oldvalue = PyCell_GET(cell);
             if (value != oldvalue) {
+                // Check that the cell can be mutated
+                if (!Py_CHECKWRITE(cell)) {
+                    PyErr_WriteToImmutable(cell);
+                    return;
+                }
+
+                // Check that the reference can be created
+                if (!Py_REGIONCHANGEREFERENCE(cell, oldvalue, value)) {
+                    return;
+                }
+
                 PyCell_SET(cell, Py_XNewRef(value));
                 Py_XDECREF(oldvalue);
             }

--- a/Objects/regions.c
+++ b/Objects/regions.c
@@ -253,6 +253,33 @@ static void regionmetadata_inc_osc(Py_region_ptr_t self_ptr)
 #define regionmetadata_inc_osc(self) \
     (regionmetadata_inc_osc(REGION_PTR_CAST(self)))
 
+/// This function checks the internal state, meaning the LRC, OSC and dirty
+/// status, to determine if the region should be closed. If possible, it will
+/// close the region and propagate the state to any parent region or cowns.
+///
+/// Returns `0` on success. An error might come from closing the region
+/// see `regionmetadata_close` for potential errors.
+static int regionmetadata_check_for_close(regionmetadata* self) {
+    // If the region is marked as dirty, we can't trust the LRC or OSC
+    // to update the status. The region has to be cleaned before it can
+    // be closed
+    if (regionmetadata_is_dirty(self)) {
+        return 0;
+    }
+
+    // The region has to remain open, if there are open subregions
+    if (self->osc != 0) {
+        return 0;
+    }
+
+    // The region has to remain open, if there are references into the region.
+    if (self->osc != 0) {
+        return 0;
+    }
+
+    return regionmetadata_close(self);
+}
+
 /// Decrements the OSC of the region. This might close the region if the LRC
 /// and ORC both hit zero and the region is not marked as dirty.
 ///
@@ -268,11 +295,7 @@ static int regionmetadata_dec_osc(Py_region_ptr_t self_ptr)
     self->osc -= 1;
 
     // Check if the OSC decrease has closed this region as well.
-    if (self->osc == 0 && self->lrc == 0 && !regionmetadata_is_dirty(self)) {
-        return regionmetadata_close(self);
-    }
-
-    return 0;
+    return regionmetadata_check_for_close(self);
 }
 #define regionmetadata_dec_osc(self) \
     (regionmetadata_dec_osc(REGION_PTR_CAST(self)))
@@ -321,6 +344,31 @@ static int regionmetadata_dec_rc(Py_region_ptr_t self_ptr)
 }
 #define regionmetadata_dec_rc(self) \
     (regionmetadata_dec_rc(REGION_PTR_CAST(self)))
+
+static void regionmetadata_inc_lrc(regionmetadata* self)
+{
+    assert(HAS_METADATA(self));
+
+    self->lrc += 1;
+    regionmetadata_open(self);
+}
+#define regionmetadata_inc_lrc(self) \
+    (regionmetadata_inc_lrc(REGION_DATA_CAST(self)))
+
+/// Decrements the LRC of the region. This might close the region if the LRC
+/// and ORC both hit zero and the region is not marked as dirty.
+///
+/// Returns `0` on success. An error might come from closing the region
+/// see `regionmetadata_close` for potential errors.
+static int regionmetadata_dec_lrc(regionmetadata* self)
+{
+    assert(HAS_METADATA(self));
+
+    self->lrc -= 1;
+    return regionmetadata_check_for_close(self);
+}
+#define regionmetadata_dec_lrc(self) \
+    (regionmetadata_dec_lrc(REGION_DATA_CAST(self)))
 
 static void regionmetadata_set_parent(regionmetadata* self, regionmetadata* parent) {
     // Just a sanity check, since these cases should never happen
@@ -473,7 +521,9 @@ int _Py_IsCown(PyObject *op)
 
 Py_region_ptr_t _Py_REGION(PyObject *ob) {
     if (!ob) {
-        return REGION_PTR_CAST(NULL);
+        // NULL is not really an object, but we want to allow pointers to be NULL
+        // so we can simply return the immutable region.
+        return _Py_IMMUTABLE;
     }
 
     Py_region_ptr_t field_value = Py_region_ptr(Py_REGION_FIELD(ob));
@@ -1935,7 +1985,7 @@ bool _Py_RegionAddReference(PyObject *src, PyObject *tgt) {
     if (_Py_IsLocal(src)) {
         // Record the borrowed reference in the LRC of the target region
         // _Py_VPYDBG("Added borrowed ref %p --> %p (owner: '%s')\n", tgt, new_ref, get_region_name(tgt));
-        Py_REGION_DATA(tgt)->lrc += 1;
+        regionmetadata_inc_lrc(Py_REGION_DATA(tgt));
         return true;
     }
 
@@ -1977,6 +2027,29 @@ void _PyRegion_set_cown_parent(PyObject* bridge, PyObject* cown) {
     Py_XSETREF(data->cown, cown);
 }
 
+bool _Py_RegionChangeReference(PyObject* src, PyObject* old_tgt, PyObject* new_tgt) {
+    // Only run the write barrier(WB) if the reference targets are different.
+    // This is important for bridge objects, as there can only be one owning
+    // reference at a time and adding a new reference first would throw a
+    // region error due to the WB believing that it would result in a second
+    // owning reference being created.
+    //
+    // Removing the reference before the new one also doesn't work. As it
+    // could cause a parent region to close prematurely and release a cown.
+    // It would also require adding the removed reference again, if the
+    // `_Py_RegionAddReference` fails.
+    if (old_tgt == new_tgt) {
+        return true;
+    }
+
+    if (!_Py_RegionAddReference(src, new_tgt)) {
+        return false;
+    }
+
+    _Py_RegionRemoveReference(src, old_tgt);
+    return true;
+}
+
 void _Py_RegionRemoveReference(PyObject *src, PyObject *tgt) {
     if (Py_REGION(src) == Py_REGION(tgt)) {
         // Nothing to do -- intra-region references have no accounting.
@@ -1995,9 +2068,8 @@ void _Py_RegionRemoveReference(PyObject *src, PyObject *tgt) {
     regionmetadata* tgt_md = Py_REGION_DATA(tgt);
     if (_Py_IsLocal(src)) {
         // Dec LRC of the previously referenced region
-        // TODO should this decrement be a function, if it hits zero,
-        // then a region could become unreachable.
-        tgt_md->lrc -= 1;
+        // TODO should errors be propagated?
+        regionmetadata_dec_lrc(tgt_md);
         return;
     }
 

--- a/Objects/regions.c
+++ b/Objects/regions.c
@@ -273,7 +273,7 @@ static int regionmetadata_check_for_close(regionmetadata* self) {
     }
 
     // The region has to remain open, if there are references into the region.
-    if (self->osc != 0) {
+    if (self->lrc != 0) {
         return 0;
     }
 
@@ -2003,7 +2003,7 @@ void _Py_RegionAddLocalReference(PyObject *tgt) {
         return;
     }
 
-    Py_REGION_DATA(tgt)->lrc += 1;
+    regionmetadata_inc_lrc(Py_REGION_DATA(tgt));
 }
 
 // Convenience function for moving multiple references into tgt at once

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1411,12 +1411,13 @@ dummy_func(
                 goto error;
             }
 
-            if (!Py_CHECKWRITE(cell)){
+            if (!Py_CHECKWRITE(cell)) {
                 format_exc_notwriteable(tstate, frame->f_code, oparg);
                 goto error;
             }
 
             PyCell_SET(cell, NULL);
+            Py_REGIONREMOVEREFERENCE(cell, oldobj);
             Py_DECREF(oldobj);
         }
 
@@ -1473,6 +1474,11 @@ dummy_func(
 
             if(!Py_CHECKWRITE(cell)){
                 format_exc_notwriteable(tstate, frame->f_code, oparg);
+                goto error;
+            }
+
+            // Check that the reference can be created
+            if (!Py_REGIONCHANGEREFERENCE(cell, oldobj, v)) {
                 goto error;
             }
 

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1980,6 +1980,13 @@ dummy_func(
             }
             PyDictValues *values = _PyDictOrValues_GetValues(dorv);
             PyObject *old_value = values->values[index];
+
+            // Check that the reference can be created
+            if (!Py_REGIONCHANGEREFERENCE(owner, old_value, value)) {
+                Py_DECREF(owner);
+                goto error;
+            }
+
             values->values[index] = value;
             if (old_value == NULL) {
                 _PyDictValues_AddToInsertionOrder(values, index);
@@ -2015,11 +2022,16 @@ dummy_func(
                 DEOPT_IF(ep->me_key != name, STORE_ATTR);
                 old_value = _PyDictEntry_Value(ep);
                 DEOPT_IF(old_value == NULL, STORE_ATTR);
-                new_version = _PyDict_NotifyEvent(tstate->interp, PyDict_EVENT_MODIFIED, dict, name, value);
-                if(_PyDictEntry_IsImmutable(ep)){
+                if (_PyDictEntry_IsImmutable(ep)) {
                     format_exc_notwriteable(tstate, frame->f_code, oparg);
+                    Py_DECREF(owner);
                     goto error;
                 }
+                if (!Py_REGIONCHANGEREFERENCE(owner, old_value, value)) {
+                    Py_DECREF(owner);
+                    goto error;
+                }
+                new_version = _PyDict_NotifyEvent(tstate->interp, PyDict_EVENT_MODIFIED, dict, name, value);
                 _PyDictEntry_SetValue(ep, value);
             }
             else {
@@ -2027,11 +2039,16 @@ dummy_func(
                 DEOPT_IF(ep->me_key != name, STORE_ATTR);
                 old_value = _PyDictEntry_Value(ep);
                 DEOPT_IF(old_value == NULL, STORE_ATTR);
-                new_version = _PyDict_NotifyEvent(tstate->interp, PyDict_EVENT_MODIFIED, dict, name, value);
-                if(_PyDictEntry_IsImmutable(ep)){
+                if (_PyDictEntry_IsImmutable(ep)) {
                     format_exc_notwriteable(tstate, frame->f_code, oparg);
+                    Py_DECREF(owner);
                     goto error;
                 }
+                if (!Py_REGIONCHANGEREFERENCE(owner, old_value, value)) {
+                    Py_DECREF(owner);
+                    goto error;
+                }
+                new_version = _PyDict_NotifyEvent(tstate->interp, PyDict_EVENT_MODIFIED, dict, name, value);
                 _PyDictEntry_SetValue(ep, value);
             }
             Py_DECREF(old_value);
@@ -2055,9 +2072,16 @@ dummy_func(
                 Py_DECREF(owner);
                 goto error;
             }
+
             char *addr = (char *)owner + index;
             STAT_INC(STORE_ATTR, hit);
             PyObject *old_value = *(PyObject **)addr;
+            // Check that the reference can be created
+            if (!Py_REGIONCHANGEREFERENCE(owner, old_value, value)) {
+                Py_DECREF(owner);
+                goto error;
+            }
+
             *(PyObject **)addr = value;
             Py_XDECREF(old_value);
             Py_DECREF(owner);


### PR DESCRIPTION
The first commit is a copy pasta from #34 and will be removed once it's merged

This PR covers all `Py_CHECKWRITE` in `bytecodes.c` and `cellobject.c`. The bytecode instructions probably still need more work for local references, but that can easily be done in a followup PR