### PR TITLE
Permitting key parts of Cowns to run without GIL

### DIFF
--- a/Lib/test/test_using.py
+++ b/Lib/test/test_using.py
@@ -159,8 +159,10 @@ class UsingTest(unittest.TestCase):
         t1.join()
         t2.join()
 
-        c.acquire()
-        result = c.get().value.value
-        c.release()
+        result = 0
+        @using(c)
+        def _():
+            nonlocal result
+            result = c.get().value.value
         if result != 200:
             self.fail()

--- a/Lib/test/test_using.py
+++ b/Lib/test/test_using.py
@@ -107,3 +107,60 @@ class UsingTest(unittest.TestCase):
     def test_invalid_cown_init(self):
          # Create cown with invalid init value
         self.assertRaises(RegionError, Cown, [42])
+
+    def test_threads(self):
+        from threading import Thread
+        from using import using
+
+
+        class Counter(object):
+            def __init__(self, value):
+                self.value = value
+
+            def inc(self):
+                self.value += 1
+
+            def dec(self):
+                self.value -= 1
+
+            def __repr__(self):
+                return "Counter(" + str(self.value) + ")"
+
+
+        # Freezes the **class** -- not needed explicitly later
+        makeimmutable(Counter)
+
+        def ThreadSafeValue(value):
+            r = Region("counter region")
+            r.value = value
+            c = Cown(r)
+            # Dropping value, r and closing not needed explicitly later
+            del value
+            del r
+            c.get().close()
+            return c
+
+        def work(c):
+            for _ in range(0, 100):
+                c.inc()
+
+        def work_in_parallel(c):
+            @using(c)
+            def _():
+                work(c.get().value)
+
+
+        c = ThreadSafeValue(Counter(0))
+
+        t1 = Thread(target=work_in_parallel, args=(c,))
+        t2 = Thread(target=work_in_parallel, args=(c,))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        c.acquire()
+        result = c.get().value.value
+        c.release()
+        if result != 200:
+            self.fail()


### PR DESCRIPTION
The release and acquire functions of Cowns did not have the appropriate permission to run without the GIL.