### PR TITLE
Make region invariant a compile option

### DIFF
--- a/.github/workflows/build_min.yml
+++ b/.github/workflows/build_min.yml
@@ -563,7 +563,7 @@ jobs:
     - name: Configure ccache action
       uses: hendrikmuhs/ccache-action@v1.2
     - name: Configure CPython
-      run: ./configure --config-cache --with-address-sanitizer --without-pymalloc
+      run: ./configure --config-cache --with-address-sanitizer --without-pymalloc --with-region-invariant
     - name: Build CPython
       run: make -j4
     - name: Display build info

--- a/.github/workflows/build_min.yml
+++ b/.github/workflows/build_min.yml
@@ -337,6 +337,7 @@ jobs:
         ../cpython-ro-srcdir/configure \
           --config-cache \
           --with-pydebug \
+          --with-region-invariant \
           --with-openssl=$OPENSSL_DIR
     - name: Build CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
@@ -460,6 +461,7 @@ jobs:
         ../cpython-ro-srcdir/configure \
           --config-cache \
           --with-pydebug \
+          --with-region-invariant \
           --with-openssl=$OPENSSL_DIR
     - name: Build CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -1057,10 +1057,12 @@ _Py_HandlePending(PyThreadState *tstate)
     struct _ceval_runtime_state *ceval = &runtime->ceval;
     struct _ceval_state *interp_ceval_state = &tstate->interp->ceval;
 
+#ifdef Py_REGION_INVARIANT
     /* Check the region invariant if required. */
     if (_Py_CheckRegionInvariant(tstate) != 0) {
         return -1;
     }
+#endif
 
     /* Pending signals */
     if (_Py_atomic_load_relaxed_int32(&ceval->signals_pending)) {

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -88,6 +88,7 @@
 #endif
 
 
+#ifdef Py_REGION_INVARIANT
 /* Do interpreter dispatch accounting for tracing and instrumentation */
 #define DISPATCH() \
     { \
@@ -97,6 +98,15 @@
         PRE_DISPATCH_GOTO(); \
         DISPATCH_GOTO(); \
     }
+#else
+/* Do interpreter dispatch accounting for tracing and instrumentation */
+#define DISPATCH() \
+    { \
+        NEXTOPARG(); \
+        PRE_DISPATCH_GOTO(); \
+        DISPATCH_GOTO(); \
+    }
+#endif
 
 #define DISPATCH_SAME_OPARG() \
     { \

--- a/configure
+++ b/configure
@@ -1078,6 +1078,7 @@ enable_shared
 with_static_libpython
 enable_profiling
 with_pydebug
+with_region_invariant
 with_trace_refs
 enable_pystats
 with_assertions
@@ -1850,6 +1851,8 @@ Optional Packages:
                           do not build libpythonMAJOR.MINOR.a and do not
                           install python.o (default is yes)
   --with-pydebug          build with Py_DEBUG defined (default is no)
+  --with-region-invariant enable region invariant for debugging purpose
+                          (default is no)
   --with-trace-refs       enable tracing references for debugging purpose
                           (default is no)
   --with-assertions       build with C assertions enabled (default is no)
@@ -8074,6 +8077,30 @@ else $as_nop
 printf "%s\n" "no" >&6; }
 fi
 
+
+# Check for --with-region-invariant
+# --with-region-invariant
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --with-region-invariant" >&5
+printf %s "checking for --with-region-invariant... " >&6; }
+
+# Check whether --with-region-invariant was given.
+if test ${with_region_invariant+y}
+then :
+  withval=$with_region_invariant;
+else $as_nop
+  with_region_invariant=yes
+
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_region_invariant" >&5
+printf "%s\n" "$with_region_invariant" >&6; }
+
+if test "$with_region_invariant" = "yes"
+then
+
+printf "%s\n" "#define Py_REGION_INVARIANT 1" >>confdefs.h
+
+fi
 
 # Check for --with-trace-refs
 # --with-trace-refs

--- a/configure.ac
+++ b/configure.ac
@@ -1689,6 +1689,21 @@ else AC_MSG_RESULT([no]); Py_DEBUG='false'
 fi],
 [AC_MSG_RESULT([no])])
 
+# Check for --with-region-invariant
+# --with-region-invariant
+AC_MSG_CHECKING([for --with-region-invariant])
+AC_ARG_WITH([region-invariant],
+  [AS_HELP_STRING([--with-region-invariant], [enable region invariant for debugging purpose (default is no)])],
+  [], [with_region_invariant=yes]
+)
+AC_MSG_RESULT([$with_region_invariant])
+
+if test "$with_region_invariant" = "yes"
+then
+  AC_DEFINE([Py_REGION_INVARIANT], [1],
+            [Define if you want to enable region invariant for debugging purpose])
+fi
+
 # Check for --with-trace-refs
 # --with-trace-refs
 AC_MSG_CHECKING([for --with-trace-refs])

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1615,6 +1615,9 @@
    SipHash13: 3, externally defined: 0 */
 #undef Py_HASH_ALGORITHM
 
+/* Define if you want to enable region invariant for debugging purpose */
+#undef Py_REGION_INVARIANT
+
 /* Define if you want to enable internal statistics gathering. */
 #undef Py_STATS
 


### PR DESCRIPTION
This makes the region invariant off by default, and requires configure to be passed:
  --with-region-invariant

This then enables the invariant to run on every byte code instruction once regions are in use.
