### PR TITLE
Added region check to tuple object

### DIFF
--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -124,6 +124,14 @@ PyTuple_SetItem(PyObject *op, Py_ssize_t i, PyObject *newitem)
         return -1;
     }
 
+    // TODO: Pyrona: Possibly optimise this case as tuples
+    // should always be in local when they are assigned.
+    if (!Py_REGIONADDREFERENCE(op, newitem)){
+        Py_XDECREF(newitem);
+        // Error set by region add test
+        return -1;
+    }
+
     if (i < 0 || i >= Py_SIZE(op)) {
         Py_XDECREF(newitem);
         PyErr_SetString(PyExc_IndexError,


### PR DESCRIPTION
As far as I can see in the source code, tuples are always created in the local region (effectively), and get their arguments before they are assigned anywhere. So the only check added to set_item should always succeed. Leaving optimising this case for future work.