### PR TITLE
Pyrona: Add and remove reference fixes in `PyObjectDict`

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -5895,21 +5895,18 @@ _PyObjectDict_SetItem(PyTypeObject *tp, PyObject **dictptr,
         if (dict == NULL) {
             dictkeys_incref(cached);
             dict = new_dict_with_shared_keys(interp, cached);
-            Py_REGIONADDREFERENCE(owner, dict);
             if (dict == NULL)
                 return -1;
+            Py_REGIONADDREFERENCE(owner, dict);
             *dictptr = dict;
         }
         if (value == NULL) {
+            // Pyrona: Remove reference is called by `DelItem`
             res = PyDict_DelItem(dict, key);
         }
         else {
-            if (Py_REGIONADDREFERENCES(dict, key, value)) {
-                res = PyDict_SetItem(dict, key, value);
-            } else {
-                // Error is set inside ADDREFERENCE
-                return -1;
-            }
+            // Pyrona: Add and remove reference is called by `SetItem`
+            res = PyDict_SetItem(dict, key, value);
         }
     } else {
         dict = *dictptr;
@@ -5921,8 +5918,10 @@ _PyObjectDict_SetItem(PyTypeObject *tp, PyObject **dictptr,
             *dictptr = dict;
         }
         if (value == NULL) {
+            // Pyrona: Remove reference is called by `DelItem`
             res = PyDict_DelItem(dict, key);
         } else {
+            // Pyrona: Add and remove reference is called by `SetItem`
             res = PyDict_SetItem(dict, key, value);
         }
     }

--- a/Objects/regions.c
+++ b/Objects/regions.c
@@ -2004,6 +2004,10 @@ void _Py_RegionRemoveReference(PyObject *src, PyObject *tgt) {
     // This must be a parent reference, so we need to remove the parent reference.
     regionmetadata* src_md = Py_REGION_DATA(src);
     regionmetadata* tgt_parent_md = REGION_DATA_CAST(Py_region_ptr(tgt_md->parent));
+    // FIXME(Pyrona): We might want to allow the `tgt_parent_md` to be NULL.
+    // This would prevent an exception if someone calls remove reference twice.
+    // We could also make this a dynamic check, which is lenient by default but
+    // can be turned strict by a flag.
     if (tgt_parent_md != src_md) {
         // TODO: Could `dirty` mean this isn't an error?
         _PyErr_Region(src, tgt, "(in WB/remove_ref)");


### PR DESCRIPTION
Fixing small issues I found while reviewing the code with Tobias