### PR TITLE
Immutable: Add invariant for debugging

### DIFF
--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -11,6 +11,7 @@ extern "C" {
 #include "pycore_immutability.h"  // struct _immutability_runtime_state
 #include "pycore_llist.h"         // struct llist_node
 #include "pycore_opcode_utils.h"  // NUM_COMMON_CONSTANTS
+#include "pycore_ownership.h"     // struct _Py_ownership_state
 #include "pycore_pymath.h"        // _PY_SHORT_FLOAT_REPR
 #include "pycore_structs.h"       // PyHamtObject
 #include "pycore_tstate.h"        // _PyThreadStateImpl
@@ -937,6 +938,7 @@ struct _is {
     struct _Py_exc_state exc_state;
     struct _Py_immutability_state immutability;
     struct _Py_mem_interp_free_queue mem_free_queue;
+    _Py_ownership_state ownership;
 
     struct ast_state ast;
     struct types_state types;

--- a/Include/internal/pycore_ownership.h
+++ b/Include/internal/pycore_ownership.h
@@ -11,33 +11,41 @@ extern "C" {
 #include "exports.h"
 
 typedef struct _Py_ownership_state {
-    /* Temporary value until the state always has a field to indicate this.
-    */
-    int is_initilized;
+    /* Temporary value until the state always has a field to indicate this. */
+    int is_initialized;
 #ifdef Py_OWNERSHIP_INVARIANT
-    /* This value indicates the state of the ownership invariant. The invariant
-    * has to support operations which might reenter into Python and then
-    * call other ownership functions. These are the states:
-    * -1 => The invariant is disabled.
-    * 0 => The invariant is enabled and running.
-    * N => The invariant is enabled but waiting on N operations as these might
-    *      temporarly violate the invariant.
-    */
+    /* Tracks the state of the ownership invariant. Some ownership-related
+     * operations may temporarily violate the invariant. To handle this safely,
+     * the invariant must be suspended during such operations and only resumed
+     * once all of them complete. This is necessary to support re-entrancy.
+     *
+     * For example, during freezing, the object graph is traversed and objects
+     * are marked as immutable — even while they may still reference mutable
+     * objects. If the invariant were enforced mid-way, it would raise a
+     * (premature) error, despite the state being corrected as the operation
+     * completes. To avoid this, the invariant must be paused during the freeze.
+     *
+     * States:
+     *  -1 => The invariant is disabled.
+     *   0 => The invariant is active and enforced.
+     *   N => The invariant is temporarily paused. The value indicates the
+     *        number of suspensions yet to be resumed (this supports nesting).
+     */
     int invariant_state;
 #endif
 } _Py_ownership_state;
 
 /* This function returns true for C wrappers around functions, types and
-* all kinds of wrappers around C with immutable state. For ownership these
-* can be seen as immutable, meaning they can be referenced from immutable
-* objects and from inside regions.
-**/
+ * all kinds of wrappers around C with immutable state. For ownership these
+ * can be seen as immutable, meaning they can be referenced from immutable
+ * objects and from inside regions.
+ */
 PyAPI_FUNC(int) _PyOwnership_is_c_wrapper(PyObject *obj);
 
 /* This function calls the `visit` function for the fields of the `obj`
-* which should be effected by ownership. The `data` pointer will be
-* passed along as the second argument to `visit`.
-*/
+ * which should be effected by ownership. The `data` pointer will be
+ * passed along as the second argument to `visit`.
+ */
 PyAPI_FUNC(int) _PyOwnership_traverse_obj(PyObject *obj, visitproc visit, void *data);
 
 #ifdef Py_OWNERSHIP_INVARIANT
@@ -49,10 +57,10 @@ PyAPI_FUNC(int) _PyOwnership_traverse_obj(PyObject *obj, visitproc visit, void *
 #define Py_OWNERSHIP_INVARIANT_ENABLED 0
 
 /* This function validates that the current heap follows the ownership
-* rules. This is a slow operation and should only be done for debugging.
-*
-* 0 indicates a valid heap, -1 will be returned if an error was thrown.
-*/
+ * rules. This is a slow operation and should only be done for debugging.
+ *
+ * 0 indicates a valid heap, -1 will be returned if an error was thrown.
+ */
 PyAPI_FUNC(int) _PyOwnership_check_invariant(PyThreadState *tstate);
 
 PyAPI_FUNC(int) _PyOwnership_invariant_enable(void);

--- a/Include/internal/pycore_ownership.h
+++ b/Include/internal/pycore_ownership.h
@@ -1,0 +1,71 @@
+#ifndef Py_INTERNAL_OWNERSHIP_H
+#define Py_INTERNAL_OWNERSHIP_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "Py_BUILD_CORE must be defined to include this header"
+#endif
+
+#include "exports.h"
+
+typedef struct _Py_ownership_state {
+    /* Temporary value until the state always has a field to indicate this.
+    */
+    int is_initilized;
+#ifdef Py_OWNERSHIP_INVARIANT
+    /* This value indicates the state of the ownership invariant. The invariant
+    * has to support operations which might reenter into Python and then
+    * call other ownership functions. These are the states:
+    * -1 => The invariant is disabled.
+    * 0 => The invariant is enabled and running.
+    * N => The invariant is enabled but waiting on N operations as these might
+    *      temporarly violate the invariant.
+    */
+    int invariant_state;
+#endif
+} _Py_ownership_state;
+
+/* This function returns true for C wrappers around functions, types and
+* all kinds of wrappers around C with immutable state. For ownership these
+* can be seen as immutable, meaning they can be referenced from immutable
+* objects and from inside regions.
+**/
+PyAPI_FUNC(int) _PyOwnership_is_c_wrapper(PyObject *obj);
+
+/* This function calls the `visit` function for the fields of the `obj`
+* which should be effected by ownership. The `data` pointer will be
+* passed along as the second argument to `visit`.
+*/
+PyAPI_FUNC(int) _PyOwnership_traverse_obj(PyObject *obj, visitproc visit, void *data);
+
+#ifdef Py_OWNERSHIP_INVARIANT
+
+#include "object.h" // PyObject, visitproc
+#include "pytypedefs.h" // PyThreadState
+
+#define Py_OWNERSHIP_INVARIANT_DISABLED -1
+#define Py_OWNERSHIP_INVARIANT_ENABLED 0
+
+/* This function validates that the current heap follows the ownership
+* rules. This is a slow operation and should only be done for debugging.
+*
+* 0 indicates a valid heap, -1 will be returned if an error was thrown.
+*/
+PyAPI_FUNC(int) _PyOwnership_check_invariant(PyThreadState *tstate);
+
+PyAPI_FUNC(int) _PyOwnership_invariant_enable(void);
+PyAPI_FUNC(int) _PyOwnership_invariant_pause(void);
+PyAPI_FUNC(int) _PyOwnership_invariant_resume(void);
+
+#else
+#   define _PyOwnership_invariant_enable() 0 /* success */
+#   define _PyOwnership_invariant_pause() 0 /* success */
+#   define _PyOwnership_invariant_resume() 0 /* success */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_OWNERSHIP_H */

--- a/Lib/test/test_freeze/test_core.py
+++ b/Lib/test/test_freeze/test_core.py
@@ -465,16 +465,6 @@ class TestWeakRef(unittest.TestCase):
         # self.assertTrue(c.val() is obj)
         self.assertIsNone(c.val())
 
-class TestStackCapture(unittest.TestCase):
-     @unittest.skip("TODO(immutable): xFrednet: Disabled see comment in frame.c")
-     def test_stack_capture(self):
-         import sys
-         x = {}
-         x["frame"] = sys._getframe()
-         freeze(x)
-         self.assertTrue(isfrozen(x))
-         self.assertTrue(isfrozen(x["frame"]))
-
 global_test_dict = 0
 class TestGlobalDictMutation(unittest.TestCase):
     def g():

--- a/Lib/test/test_freeze/test_core.py
+++ b/Lib/test/test_freeze/test_core.py
@@ -466,6 +466,7 @@ class TestWeakRef(unittest.TestCase):
         self.assertIsNone(c.val())
 
 class TestStackCapture(unittest.TestCase):
+     @unittest.skip("TODO(immutable): xFrednet: Disabled see comment in frame.c")
      def test_stack_capture(self):
          import sys
          x = {}

--- a/Lib/test/test_freeze/test_gc.py
+++ b/Lib/test/test_freeze/test_gc.py
@@ -1,6 +1,6 @@
 from gc import collect
 import unittest
-from immutable import freeze, NotFreezable, isfrozen
+from immutable import freeze
 
 class GCInteropTest(unittest.TestCase):
   def test_collect(self):

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -474,6 +474,7 @@ PYTHON_OBJS=	\
 		Python/optimizer.o \
 		Python/optimizer_analysis.o \
 		Python/optimizer_symbols.o \
+		Python/ownership.o \
 		Python/parking_lot.o \
 		Python/pathconfig.o \
 		Python/preconfig.o \
@@ -1356,6 +1357,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/internal/pycore_opcode_metadata.h \
 		$(srcdir)/Include/internal/pycore_opcode_utils.h \
 		$(srcdir)/Include/internal/pycore_optimizer.h \
+		$(srcdir)/Include/internal/pycore_ownership.h \
 		$(srcdir)/Include/internal/pycore_parking_lot.h \
 		$(srcdir)/Include/internal/pycore_parser.h \
 		$(srcdir)/Include/internal/pycore_pathconfig.h \

--- a/PCbuild/_freeze_module.vcxproj
+++ b/PCbuild/_freeze_module.vcxproj
@@ -243,6 +243,7 @@
     <ClCompile Include="..\Python\optimizer.c" />
     <ClCompile Include="..\Python\optimizer_analysis.c" />
     <ClCompile Include="..\Python\optimizer_symbols.c" />
+    <ClCompile Include="..\Python\ownership.c" />
     <ClCompile Include="..\Python\parking_lot.c" />
     <ClCompile Include="..\Python\pathconfig.c" />
     <ClCompile Include="..\Python\perf_trampoline.c" />

--- a/PCbuild/_freeze_module.vcxproj.filters
+++ b/PCbuild/_freeze_module.vcxproj.filters
@@ -328,6 +328,9 @@
     <ClCompile Include="..\Python\optimizer_symbols.c">
       <Filter>Python</Filter>
     </ClCompile>
+    <ClCompile Include="..\Python\ownership.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\Parser\parser.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -285,6 +285,7 @@
     <ClInclude Include="..\Include\internal\pycore_obmalloc.h" />
     <ClInclude Include="..\Include\internal\pycore_obmalloc_init.h" />
     <ClInclude Include="..\Include\internal\pycore_optimizer.h" />
+    <ClInclude Include="..\Include\internal\pycore_ownership.h" />
     <ClInclude Include="..\Include\internal\pycore_parking_lot.h" />
     <ClInclude Include="..\Include\internal\pycore_pathconfig.h" />
     <ClInclude Include="..\Include\internal\pycore_pyarena.h" />
@@ -640,6 +641,7 @@
     <ClCompile Include="..\Python\optimizer.c" />
     <ClCompile Include="..\Python\optimizer_analysis.c" />
     <ClCompile Include="..\Python\optimizer_symbols.c" />
+    <ClCompile Include="..\Python\ownership.c" />
     <ClCompile Include="..\Python\parking_lot.c" />
     <ClCompile Include="..\Python\pathconfig.c" />
     <ClCompile Include="..\Python\perf_trampoline.c" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -694,6 +694,8 @@
       <Filter>Include\internal</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_index_pool.h">
+      <Filter>Include\internal</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_immutability.h">
       <Filter>Include\internal</Filter>
     </ClInclude>
@@ -1427,6 +1429,8 @@
       <Filter>Python</Filter>
     </ClCompile>
     <ClCompile Include="..\Python\index_pool.c">
+      <Filter>Python</Filter>
+    </ClCompile>
     <ClCompile Include="..\Python\immutability.c">
       <Filter>Python</Filter>
     </ClCompile>
@@ -1476,6 +1480,9 @@
       <Filter>Python</Filter>
     </ClCompile>
     <ClCompile Include="..\Python\optimizer_symbols.c">
+      <Filter>Python</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Python\ownership.c">
       <Filter>Python</Filter>
     </ClCompile>
     <ClCompile Include="..\Python\parking_lot.c">

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -29,6 +29,7 @@
 #include "pycore_opcode_metadata.h" // EXTRA_CASES
 #include "pycore_opcode_utils.h"  // MAKE_FUNCTION_*
 #include "pycore_optimizer.h"     // _PyUOpExecutor_Type
+#include "pycore_ownership.h"     // _PyOwnership_check_invariant
 #include "pycore_pyatomic_ft_wrappers.h" // FT_ATOMIC_*
 #include "pycore_pyerrors.h"      // _PyErr_GetRaisedException()
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -7,7 +7,7 @@
 #include "pycore_pylifecycle.h"   // _PyErr_Print()
 #include "pycore_pystats.h"       // _Py_PrintSpecializationStats()
 #include "pycore_runtime.h"       // _PyRuntime
-
+#include "pycore_ownership.h"     // _PyOwnership_check_invariant
 
 /*
    Notes about the implementation:
@@ -1366,6 +1366,13 @@ _Py_HandlePending(PyThreadState *tstate)
         /* The attach blocks until the stop-the-world event is complete. */
         _PyThreadState_Attach(tstate);
     }
+
+#ifdef Py_OWNERSHIP_INVARIANT
+    /* Check the region invariant if required. */
+    if (_PyOwnership_check_invariant(tstate) != 0) {
+        return -1;
+    }
+#endif
 
     /* Pending signals */
     if ((breaker & _PY_SIGNALS_PENDING_BIT) != 0) {

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -150,13 +150,26 @@ do { \
 
 
 /* Do interpreter dispatch accounting for tracing and instrumentation */
-#define DISPATCH() \
+#ifdef Py_OWNERSHIP_INVARIANT
+#  define DISPATCH() \
+    { \
+        if (_PyOwnership_check_invariant(tstate) != 0) { \
+            JUMP_TO_LABEL(error); \
+        } \
+        assert(frame->stackpointer == NULL); \
+        NEXTOPARG(); \
+        PRE_DISPATCH_GOTO(); \
+        DISPATCH_GOTO(); \
+    }
+#else
+#  define DISPATCH() \
     { \
         assert(frame->stackpointer == NULL); \
         NEXTOPARG(); \
         PRE_DISPATCH_GOTO(); \
         DISPATCH_GOTO(); \
     }
+#endif
 
 #define DISPATCH_SAME_OPARG() \
     { \

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -79,13 +79,6 @@ take_ownership(PyFrameObject *f, _PyInterpreterFrame *frame)
             PyErr_Clear();
         }
         else {
-            // TODO(immutable): xFrednet: This can modify a frozen frame object
-            // it's a bit weird, that his is updated after a frame object can be
-            // accessed from Python. Anyhow.
-            // A fundemental question is, if frame objects should be freezeable
-            // in the first place. It seems impractical for sharing and turns
-            // basically the whole world immutable. We should probably just
-            // mark it as not freezable.
             f->f_back = (PyFrameObject *)Py_NewRef(back);
         }
         PyErr_SetRaisedException(exc);

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -79,6 +79,13 @@ take_ownership(PyFrameObject *f, _PyInterpreterFrame *frame)
             PyErr_Clear();
         }
         else {
+            // TODO(immutable): xFrednet: This can modify a frozen frame object
+            // it's a bit weird, that his is updated after a frame object can be
+            // accessed from Python. Anyhow.
+            // A fundemental question is, if frame objects should be freezeable
+            // in the first place. It seems impractical for sharing and turns
+            // basically the whole world immutable. We should probably just
+            // mark it as not freezable.
             f->f_back = (PyFrameObject *)Py_NewRef(back);
         }
         PyErr_SetRaisedException(exc);

--- a/Python/immutability.c
+++ b/Python/immutability.c
@@ -5,8 +5,9 @@
 #include <stdio.h>
 #include "pycore_descrobject.h"
 #include "pycore_gc.h"
-#include "pycore_object.h"
 #include "pycore_immutability.h"
+#include "pycore_object.h"
+#include "pycore_ownership.h"
 #include "pycore_list.h"
 
 
@@ -150,10 +151,6 @@ static PyObject* pop(PyObject* s){
     }
 
     return item;
-}
-
-static bool is_c_wrapper(PyObject* obj){
-    return PyCFunction_Check(obj) || Py_IS_TYPE(obj, &_PyMethodWrapper_Type) || Py_IS_TYPE(obj, &PyWrapperDescr_Type);
 }
 
 // Lifted from Python/gc.c
@@ -775,7 +772,7 @@ int _Py_DecRef_Immutable(PyObject *op)
 
 int traverse_freeze(PyObject* obj, PyObject* dfs)
 {
-    if(is_c_wrapper(obj)) {
+    if(_PyOwnership_is_c_wrapper(obj)) {
         // C functions are not mutable
         // Types are manually traversed
         return 0;
@@ -788,33 +785,9 @@ int traverse_freeze(PyObject* obj, PyObject* dfs)
         SUCCEEDS(shadow_function_globals(obj));
     }
 
-    if(PyType_Check(obj)){
-        // TODO(Immutable): mjp: Special case for types not sure if required. We should review.
-        PyTypeObject* type = (PyTypeObject*)obj;
-
-        SUCCEEDS(freeze_visit(type->tp_dict, dfs));
-        SUCCEEDS(freeze_visit(type->tp_mro, dfs));
-        // We need to freeze the tuple object, even though the types
-        // within will have been frozen already.
-        SUCCEEDS(freeze_visit(type->tp_bases, dfs));
-    }
-    else
-    {
-        traverseproc traverse = Py_TYPE(obj)->tp_traverse;
-        if(traverse != NULL){
-            SUCCEEDS(traverse(obj, (visitproc)freeze_visit, dfs));
-        }
-    }
-
-    // The default tp_traverse will not visit the type object if it is
-    // not heap allocated, so we need to do that manually here to freeze
-    // the statically allocated types that are reachable.
-    if (!(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_HEAPTYPE)) {
-        SUCCEEDS(freeze_visit(_PyObject_CAST(Py_TYPE(obj)), dfs));
-    }
+    SUCCEEDS(_PyOwnership_traverse_obj(obj, (visitproc)freeze_visit, (void*)dfs));
 
     return 0;
-
 error:
     return -1;
 }
@@ -827,6 +800,21 @@ int _PyImmutability_Freeze(PyObject* obj)
     }
     int result = 0;
 
+#ifdef Py_DEBUG
+    // This has to be declared early to support the `Py_XDECREF` if any of the
+    // `SUCCEEDS` fails
+    PyObject* freeze_location = NULL;
+#endif
+
+    // Enable the invariant. It has to be enabled at the beginning to allow
+    // reentry and failure in internal calls.
+    SUCCEEDS(_PyOwnership_invariant_enable());
+    // This function incrementally marks new objects as frozen. During this
+    // process it is possible that frozen objects point to mutable ones. This
+    // therefore needs to pause the invariant. Otherwise we might get an
+    // exception when freezing calls into Python and triggers the invariant.
+    SUCCEEDS(_PyOwnership_invariant_pause());
+
     struct FreezeState freeze_state;
     // Initialize the freeze state
     SUCCEEDS(init_freeze_state(&freeze_state));
@@ -836,9 +824,7 @@ int _PyImmutability_Freeze(PyObject* obj)
         goto error;
     }
 
-
 #ifdef Py_DEBUG
-    PyObject* freeze_location = NULL;
     // In debug mode, we can set a freeze location for debugging purposes.
     // Get a traceback object to use as the freeze location.
     if (state->traceback_func == NULL) {
@@ -900,5 +886,11 @@ finally:
 #ifdef Py_DEBUG
     Py_XDECREF(freeze_location);
 #endif
+    // Indicate that this funciton no longer requires the invariant to be paused.
+    // This can't use the `SUCCEEDS` macro, since that one would jump to the
+    // `error` label above.
+    if (_PyOwnership_invariant_resume() != 0) {
+        result = -1;
+    }
     return result;
 }

--- a/Python/ownership.c
+++ b/Python/ownership.c
@@ -1,0 +1,248 @@
+#include "Python.h"
+#include <stdbool.h>
+#include "object.h"             // _Py_IsImmutable
+#include "pycore_descrobject.h" // _PyMethodWrapper_Type
+#include "pycore_gc.h"          // _PyGCHead_NEXT, _PyGCHead_PREV, _Py_FROM_GC
+#include "pycore_interp.h"      // PyThreadState_Get
+#include "pycore_ownership.h"
+#include "pycore_pyerrors.h"
+#include "pycore_runtime.h"
+#include "pyerrors.h"
+#include "refcount.h"
+
+// Macro that jumps to error, if the expression `x` does not succeed.
+#define SUCCEEDS(x) { do { int r = (x); if (r != 0) goto error; } while (0); }
+
+static int init_state(_Py_ownership_state *state)
+{
+    state->is_initilized = true;
+#ifdef Py_OWNERSHIP_INVARIANT
+    state->invariant_state = Py_OWNERSHIP_INVARIANT_DISABLED;
+#endif
+    return 0;
+}
+
+static _Py_ownership_state* get_ownership_state()
+{
+    PyInterpreterState *interp = PyInterpreterState_Get();
+    if (interp == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to get the interpreter state");
+        return NULL;
+    }
+
+    _Py_ownership_state *state = &interp->ownership;
+    if (state->is_initilized == false) {
+        if (init_state(state) == -1) {
+            PyErr_SetString(PyExc_RuntimeError, "Failed to initialize ownership state");
+            return NULL;
+        }
+    }
+
+    return state;
+}
+
+int _PyOwnership_is_c_wrapper(PyObject* obj){
+    return PyCFunction_Check(obj) || Py_IS_TYPE(obj, &_PyMethodWrapper_Type) || Py_IS_TYPE(obj, &PyWrapperDescr_Type);
+}
+int _PyOwnership_traverse_obj(PyObject *obj, visitproc visit, void *data) {
+    if (PyType_Check(obj)) {
+        // TODO(Immutable): mjp: Special case for types not sure if required. We should review.
+        // Additional Note: xFrednet: It looks like each type has a handle to
+        // its module, so this is probably needed unless we want to freeze or
+        // replace the module pointer?
+        PyTypeObject* type = (PyTypeObject*)obj;
+
+        SUCCEEDS(visit(type->tp_dict, data));
+        SUCCEEDS(visit(type->tp_mro, data));
+        // We need to freeze the tuple object, even though the types
+        // within will have been frozen already.
+        SUCCEEDS(visit(type->tp_bases, data));
+    }
+    else
+    {
+        traverseproc traverse = Py_TYPE(obj)->tp_traverse;
+        if(traverse != NULL){
+            SUCCEEDS(traverse(obj, visit, data));
+        }
+    }
+
+    // tp_traverse doesn't cover the object type, this therefore needs
+    // to explicitly visit the type.
+    SUCCEEDS(visit(_PyObject_CAST(Py_TYPE(obj)), data));
+
+    return 0;
+error:
+    return -1;
+}
+
+// All code belonging to the invariant
+#if Py_OWNERSHIP_INVARIANT
+
+// FIXME(Pyrona): This should be on a "Per interpreter state"
+bool is_invariant_enabled = false;
+
+static void throw_invariant_error(
+    PyObject* src,
+    PyObject* tgt,
+    const char *format_str,
+    PyObject *format_arg
+) {
+    // Don't stomp existing exception
+    PyThreadState *tstate = PyThreadState_Get();
+    if (!tstate || _PyErr_Occurred(tstate)) {
+        return;
+    }
+
+    // Create the error, this sets the error value in `tstate`
+    PyErr_Format(PyExc_RuntimeError, format_str, format_arg);
+
+    // Set source and target fields
+    // Get the current exception (should be a RuntimeError)
+    PyObject *exc = PyErr_GetRaisedException();
+    assert(exc && PyObject_TypeCheck(exc, (PyTypeObject *)PyExc_RuntimeError));
+
+    // Add 'source' and 'target' attributes to the exception
+    PyObject_SetAttr(exc, &_Py_ID(source), src ? src : Py_None);
+    PyObject_SetAttr(exc, &_Py_ID(target), tgt ? tgt : Py_None);
+
+    PyErr_SetRaisedException((PyObject*)exc);
+}
+
+// Lifted from Python/gc.c
+//******************************** */
+typedef struct _gc_runtime_state GCState;
+#define GEN_HEAD(gcstate, n) ((n == 0) ? (&(gcstate)->young.head) : (&(gcstate)->old[n - 1].head))
+#define GC_NEXT _PyGCHead_NEXT
+#define GC_PREV _PyGCHead_PREV
+#define FROM_GC _Py_FROM_GC
+//******************************** */
+
+static int check_invariant_visit_immutable(PyObject* tgt, void* src_void) {
+    PyObject* src = (PyObject*)src_void;
+
+    // C wrappers are special and allowed
+    if (_PyOwnership_is_c_wrapper(tgt)) {
+        return 0;
+    }
+
+    // Make sure the immutable source only points to immutable objects
+    if (!_Py_IsImmutable(tgt)) {
+        throw_invariant_error(
+            src, tgt,
+            "Invariant Error: An immutable objects points to a mutable one",
+            Py_None);
+        return -1;
+    }
+
+    return 0;
+}
+
+int _PyOwnership_check_invariant(PyThreadState *tstate) {
+    _Py_ownership_state *state = get_ownership_state();
+    if (state == NULL) {
+        return -1;
+    }
+
+    // Only run the invariant if it's actully enabled and there is no
+    // function which paused the invariant
+    if (state->invariant_state != Py_OWNERSHIP_INVARIANT_ENABLED) {
+        return 0;
+    }
+
+    // Don't run during shutdown. Python needs to mutate data in this state
+    // and any breakage will not really matter, since this universe is at
+    // its end.
+    if (Py_IsFinalizing()) {
+        state->invariant_state = Py_OWNERSHIP_INVARIANT_DISABLED;
+        return 0;
+    }
+
+    // Don't stomp existing exceptions
+    if (_PyErr_Occurred(tstate)) {
+        return 0;
+    }
+
+    // Use the GC data to find all the objects, and traverse them to
+    // confirm all their references satisfy the invariant.
+    GCState *gcstate = &tstate->interp->gc;
+
+    // There is an cyclic doubly linked list per generation of all the objects
+    // in that generation.
+    for (int i = NUM_GENERATIONS-1; i >= 0; i--) {
+        PyGC_Head *containers = GEN_HEAD(gcstate, i);
+        PyGC_Head *gc = GC_NEXT(containers);
+        // Walk doubly linked list of objects.
+        for (; gc != containers; gc = GC_NEXT(gc)) {
+            PyObject *ob = FROM_GC(gc);
+
+            // C wrappers are complicated see description of the called
+            // function. We treat them as immutable objects. But we
+            // don't traverse them.
+            if (_PyOwnership_is_c_wrapper(ob)) {
+                continue;
+            }
+
+            // Select which validation function should be used, based on the
+            // current object.
+            visitproc visit = NULL;
+            if (_Py_IsImmutable(ob)) {
+                visit = (visitproc)check_invariant_visit_immutable;
+            } else {
+                // The object shouldn't be validated.
+                // (This surely won't backfire on us)
+                continue;
+            }
+
+            // Use traverse proceduce to visit each field of the object.
+            SUCCEEDS(_PyOwnership_traverse_obj(ob, visit, ob));
+        }
+    }
+
+    return 0;
+
+error:
+    // Disable the invariant
+    state->invariant_state = Py_OWNERSHIP_INVARIANT_DISABLED;
+    // Return -1 to indicate an error
+    return -1;
+}
+
+int _PyOwnership_invariant_enable(void) {
+    _Py_ownership_state *state = get_ownership_state();
+    if (state == NULL) {
+        return -1;
+    }
+
+    if (state->invariant_state == Py_OWNERSHIP_INVARIANT_DISABLED) {
+        state->invariant_state = Py_OWNERSHIP_INVARIANT_ENABLED;
+    }
+
+    return 0;
+}
+
+int _PyOwnership_invariant_pause(void) {
+    _Py_ownership_state *state = get_ownership_state();
+    if (state == NULL) {
+        return -1;
+    }
+
+    if (state->invariant_state != Py_OWNERSHIP_INVARIANT_DISABLED) {
+        state->invariant_state += 1;
+    }
+
+    return 0;
+}
+
+int _PyOwnership_invariant_resume(void) {
+    _Py_ownership_state *state = get_ownership_state();
+    if (state == NULL) {
+        return -1;
+    }
+
+    if (state->invariant_state != Py_OWNERSHIP_INVARIANT_DISABLED) {
+        state->invariant_state -= 1;
+    }
+
+    return 0;
+}
+#endif /* Py_OWNERSHIP_INVARIANT */

--- a/Python/ownership.c
+++ b/Python/ownership.c
@@ -15,7 +15,7 @@
 
 static int init_state(_Py_ownership_state *state)
 {
-    state->is_initilized = true;
+    state->is_initialized = true;
 #ifdef Py_OWNERSHIP_INVARIANT
     state->invariant_state = Py_OWNERSHIP_INVARIANT_DISABLED;
 #endif
@@ -31,7 +31,7 @@ static _Py_ownership_state* get_ownership_state()
     }
 
     _Py_ownership_state *state = &interp->ownership;
-    if (state->is_initilized == false) {
+    if (state->is_initialized == false) {
         if (init_state(state) == -1) {
             PyErr_SetString(PyExc_RuntimeError, "Failed to initialize ownership state");
             return NULL;
@@ -76,10 +76,7 @@ error:
 }
 
 // All code belonging to the invariant
-#if Py_OWNERSHIP_INVARIANT
-
-// FIXME(Pyrona): This should be on a "Per interpreter state"
-bool is_invariant_enabled = false;
+#ifdef Py_OWNERSHIP_INVARIANT
 
 static void throw_invariant_error(
     PyObject* src,
@@ -188,8 +185,9 @@ int _PyOwnership_check_invariant(PyThreadState *tstate) {
             if (_Py_IsImmutable(ob)) {
                 visit = (visitproc)check_invariant_visit_immutable;
             } else {
-                // The object shouldn't be validated.
-                // (This surely won't backfire on us)
+                // Mutable objects are allowed to reference all other objects
+                // (regardless if mutable or not). These therefore don't need
+                // to be traversed.
                 continue;
             }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -796,6 +796,11 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
     Py_CLEAR(interp->immutability.freezable_types);
     Py_CLEAR(interp->immutability.destroy_cb);
 
+    interp->ownership.is_initilized = 0;
+#ifdef Py_OWNERSHIP_INVARIANT
+    interp->ownership.invariant_state = Py_OWNERSHIP_INVARIANT_DISABLED;
+#endif
+
     Py_CLEAR(interp->sysdict_copy);
     Py_CLEAR(interp->builtins_copy);
     Py_CLEAR(interp->dict);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -796,7 +796,7 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
     Py_CLEAR(interp->immutability.freezable_types);
     Py_CLEAR(interp->immutability.destroy_cb);
 
-    interp->ownership.is_initilized = 0;
+    interp->ownership.is_initialized = 0;
 #ifdef Py_OWNERSHIP_INVARIANT
     interp->ownership.invariant_state = Py_OWNERSHIP_INVARIANT_DISABLED;
 #endif

--- a/configure
+++ b/configure
@@ -1095,6 +1095,7 @@ with_static_libpython
 enable_profiling
 enable_gil
 with_pydebug
+with_ownership_invariant
 with_trace_refs
 enable_pystats
 with_assertions
@@ -1882,6 +1883,9 @@ Optional Packages:
                           do not build libpythonMAJOR.MINOR.a and do not
                           install python.o (default is yes)
   --with-pydebug          build with Py_DEBUG defined (default is no)
+  --with-ownership-invariant
+                          enable ownership invariant for debugging purpose
+                          (default is no)
   --with-trace-refs       enable tracing references for debugging purpose
                           (default is no)
   --with-assertions       build with C assertions enabled (default is no)
@@ -8295,6 +8299,31 @@ printf "%s\n" "no" >&6; } ;;
 esac
 fi
 
+
+# Check for --with-ownership-invariant
+# --with-ownership-invariant
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --with-ownership-invariant" >&5
+printf %s "checking for --with-ownership-invariant... " >&6; }
+
+# Check whether --with-ownership-invariant was given.
+if test ${with_ownership_invariant+y}
+then :
+  withval=$with_ownership_invariant;
+else case e in #(
+  e) with_ownership_invariant=no
+ ;;
+esac
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_ownership_invariant" >&5
+printf "%s\n" "$with_ownership_invariant" >&6; }
+
+if test "$with_ownership_invariant" = "yes"
+then
+
+printf "%s\n" "#define Py_OWNERSHIP_INVARIANT 1" >>confdefs.h
+
+fi
 
 # Check for --with-trace-refs
 # --with-trace-refs

--- a/configure.ac
+++ b/configure.ac
@@ -1746,6 +1746,21 @@ else AC_MSG_RESULT([no]); Py_DEBUG='false'
 fi],
 [AC_MSG_RESULT([no])])
 
+# Check for --with-ownership-invariant
+# --with-ownership-invariant
+AC_MSG_CHECKING([for --with-ownership-invariant])
+AC_ARG_WITH([ownership-invariant],
+  [AS_HELP_STRING([--with-ownership-invariant], [enable ownership invariant for debugging purpose (default is no)])],
+  [], [with_ownership_invariant=no]
+)
+AC_MSG_RESULT([$with_ownership_invariant])
+
+if test "$with_ownership_invariant" = "yes"
+then
+  AC_DEFINE([Py_OWNERSHIP_INVARIANT], [1],
+            [Define if you want to enable ownership invariant for debugging purpose])
+fi
+
 # Check for --with-trace-refs
 # --with-trace-refs
 AC_MSG_CHECKING([for --with-trace-refs])

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1714,6 +1714,9 @@
 /* Define to 1 if you have the perf trampoline. */
 #undef PY_HAVE_PERF_TRAMPOLINE
 
+/* Define if you want to enable ownership invariant for debugging purpose */
+#undef Py_OWNERSHIP_INVARIANT
+
 /* Define to 1 to build the sqlite module with loadable extensions support. */
 #undef PY_SQLITE_ENABLE_LOAD_EXTENSION
 


### PR DESCRIPTION
This PR adds an invariant, which checks that immutable objects can only reach other immutable objects. This invariant is checked after every byte-code instruction execution, once an object was frozen.

It also helped to find two violations in the implementation:
1. Frame objects are complicated and probably shouldn't be freezable (Left as a TODO)
2. Freezing always as to visit the type (Fixed and documented)

The frame object bug was really interesting. I don't think we would have found this mutation without the help of the new invariant. Therefore, I would advocate for including it in our change set. Maybe rename some of the "ownership" to "immutable", but that should be it.