### PR TITLE
Add "can be viewed as immutable" query to the immutability system

### DIFF
--- a/Include/cpython/immutability.h
+++ b/Include/cpython/immutability.h
@@ -6,3 +6,5 @@ PyAPI_DATA(PyTypeObject) _PyNotFreezable_Type;
 
 PyAPI_FUNC(int) _PyImmutability_Freeze(PyObject*);
 PyAPI_FUNC(int) _PyImmutability_RegisterFreezable(PyTypeObject*);
+PyAPI_FUNC(int) _PyImmutability_RegisterShallowImmutable(PyTypeObject*);
+PyAPI_FUNC(int) _PyImmutability_CanViewAsImmutable(PyObject*);

--- a/Include/internal/pycore_immutability.h
+++ b/Include/internal/pycore_immutability.h
@@ -14,6 +14,7 @@ struct _Py_immutability_state {
     PyObject *module_locks;
     PyObject *blocking_on;
     PyObject *freezable_types;
+    _Py_hashtable_t *shallow_immutable_types;
     PyObject *destroy_cb;
     _Py_hashtable_t *warned_types;
 #ifdef Py_DEBUG

--- a/Lib/test/test_freeze/test_implicit.py
+++ b/Lib/test/test_freeze/test_implicit.py
@@ -1,0 +1,144 @@
+import unittest
+from immutable import freeze, isfrozen
+
+
+class TestImplicitImmutability(unittest.TestCase):
+    """Tests for objects that can be viewed as immutable."""
+
+    def test_tuple_of_immortal_ints(self):
+        """A tuple of small ints (immortal) can be viewed as immutable."""
+        obj = (1, 2, 3)
+        self.assertTrue(isfrozen(obj))
+
+    def test_tuple_of_strings(self):
+        """A tuple of interned strings can be viewed as immutable."""
+        obj = ("hello", "world")
+        self.assertTrue(isfrozen(obj))
+
+    def test_tuple_of_none(self):
+        """A tuple containing None can be viewed as immutable."""
+        obj = (None, None)
+        self.assertTrue(isfrozen(obj))
+
+    def test_nested_tuples(self):
+        """Nested tuples of immortal objects can be viewed as immutable."""
+        obj = ((1, 2), (3, (4, 5)))
+        self.assertTrue(isfrozen(obj))
+
+    def test_tuple_with_mutable_list(self):
+        """A tuple containing a mutable list cannot be viewed as immutable."""
+        obj = (1, [2, 3])
+        self.assertFalse(isfrozen(obj))
+
+    def test_tuple_with_mutable_dict(self):
+        """A tuple containing a mutable dict cannot be viewed as immutable."""
+        obj = (1, {"a": 2})
+        self.assertFalse(isfrozen(obj))
+
+    def test_frozenset_of_ints(self):
+        """A frozenset of ints can be viewed as immutable."""
+        obj = frozenset([1, 2, 3])
+        self.assertTrue(isfrozen(obj))
+
+    def test_empty_tuple(self):
+        """An empty tuple can be viewed as immutable."""
+        obj = ()
+        self.assertTrue(isfrozen(obj))
+
+    def test_empty_frozenset(self):
+        """An empty frozenset can be viewed as immutable."""
+        obj = frozenset()
+        self.assertTrue(isfrozen(obj))
+
+    def test_already_frozen_object(self):
+        """An already-frozen object should return True."""
+        obj = [1, 2, 3]
+        freeze(obj)
+        self.assertTrue(isfrozen(obj))
+
+    def test_tuple_containing_frozen_object(self):
+        """A tuple containing a frozen list can be viewed as immutable."""
+        inner = [1, 2, 3]
+        freeze(inner)
+        obj = (inner, 4, 5)
+        self.assertTrue(isfrozen(obj))
+
+    def test_mutable_list(self):
+        """A plain mutable list cannot be viewed as immutable."""
+        obj = [1, 2, 3]
+        self.assertFalse(isfrozen(obj))
+
+    def test_mutable_dict(self):
+        """A plain mutable dict cannot be viewed as immutable."""
+        obj = {"a": 1}
+        self.assertFalse(isfrozen(obj))
+
+    def test_tuple_with_bytes(self):
+        """A tuple containing bytes can be viewed as immutable."""
+        obj = (b"hello", b"world")
+        self.assertTrue(isfrozen(obj))
+
+    def test_tuple_with_float(self):
+        """A tuple with floats can be viewed as immutable."""
+        obj = (1.0, 2.5, 3.14)
+        self.assertTrue(isfrozen(obj))
+
+    def test_tuple_with_complex(self):
+        """A tuple with complex numbers can be viewed as immutable."""
+        obj = (1+2j, 3+4j)
+        self.assertTrue(isfrozen(obj))
+
+    def test_tuple_with_bool(self):
+        """A tuple with booleans can be viewed as immutable."""
+        obj = (True, False)
+        self.assertTrue(isfrozen(obj))
+
+    def test_isfrozen_freezes_non_immortal(self):
+        """A graph that can be viewed as immutable gets frozen by isfrozen."""
+        big = 10**100
+        obj = (big,)
+        result = isfrozen(obj)
+        self.assertTrue(result)
+        self.assertTrue(isfrozen(obj))
+
+    def test_tuple_of_range(self):
+        """A tuple containing a range object can be viewed as immutable."""
+        obj = (range(10),)
+        self.assertTrue(isfrozen(obj))
+
+    def test_deeply_nested(self):
+        """Deeply nested tuples can be viewed as immutable."""
+        obj = (1,)
+        for _ in range(100):
+            obj = (obj,)
+        self.assertTrue(isfrozen(obj))
+
+    def test_tuple_with_set(self):
+        """A tuple containing a mutable set cannot be viewed as immutable."""
+        obj = (1, {2, 3})
+        self.assertFalse(isfrozen(obj))
+
+    def test_c_shallow_immutable_type(self):
+        """A C type registered as shallow immutable can be viewed as immutable."""
+        import _test_reachable
+        freeze(_test_reachable.ShallowImmutable)
+        obj = (_test_reachable.ShallowImmutable(1),)
+        self.assertTrue(isfrozen(obj))
+
+    def test_c_shallow_immutable_with_mutable_referent(self):
+        """A C shallow immutable containing a mutable object cannot be viewed as immutable."""
+        import _test_reachable
+        freeze(_test_reachable.ShallowImmutable)
+        obj = (_test_reachable.ShallowImmutable([1, 2]),)
+        self.assertFalse(isfrozen(obj))
+
+    def test_deeply_nested_no_stack_overflow(self):
+        """Very deep nesting should not cause a stack overflow."""
+        obj = (1,)
+        for _ in range(10000):
+            obj = (obj,)
+        self.assertTrue(isfrozen(obj))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Modules/_immutablemodule.c
+++ b/Modules/_immutablemodule.c
@@ -101,17 +101,23 @@ _immutable.isfrozen
     obj: object
     /
 
-Check if an object is frozen.
+Check if an object is frozen (or can be viewed as immutable).
+
+If the object graph can be viewed as immutable, it will be frozen as a
+side effect and True is returned.
 [clinic start generated code]*/
 
 static PyObject *
 _immutable_isfrozen(PyObject *module, PyObject *obj)
 /*[clinic end generated code: output=5857a038e2a68ed7 input=8dc5ebd880c4c8b2]*/
 {
-    if(_Py_IsImmutable(obj)){
+    int result = _PyImmutability_CanViewAsImmutable(obj);
+    if (result < 0) {
+        return NULL;
+    }
+    if (result) {
         Py_RETURN_TRUE;
     }
-
     Py_RETURN_FALSE;
 }
 

--- a/Modules/_immutablemodule.c
+++ b/Modules/_immutablemodule.c
@@ -109,7 +109,7 @@ side effect and True is returned.
 
 static PyObject *
 _immutable_isfrozen(PyObject *module, PyObject *obj)
-/*[clinic end generated code: output=5857a038e2a68ed7 input=8dc5ebd880c4c8b2]*/
+/*[clinic end generated code: output=5857a038e2a68ed7 input=f60302e01ab45c4d]*/
 {
     int result = _PyImmutability_CanViewAsImmutable(obj);
     if (result < 0) {

--- a/Modules/_test_reachable.c
+++ b/Modules/_test_reachable.c
@@ -166,6 +166,77 @@ static PyTypeObject HasReachable_Type = {
 
 /* ---- Module ---------------------------------------------------------- */
 
+/* ---- ShallowImmutable ------------------------------------------------ */
+/*
+ * A C-level type registered as shallow immutable via
+ * _PyImmutability_RegisterShallowImmutable.  Instances hold a single
+ * PyObject* but are declared shallow-immutable, meaning the implicit
+ * check trusts that the instance itself won't be mutated.
+ */
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *value;
+} ShallowImmutableObject;
+
+static int
+si_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    ShallowImmutableObject *obj = (ShallowImmutableObject *)self;
+    Py_VISIT(obj->value);
+    return 0;
+}
+
+static int
+si_reachable(PyObject *self, visitproc visit, void *arg)
+{
+    Py_VISIT(Py_TYPE(self));
+    return si_traverse(self, visit, arg);
+}
+
+static int
+si_clear(PyObject *self)
+{
+    ShallowImmutableObject *obj = (ShallowImmutableObject *)self;
+    Py_CLEAR(obj->value);
+    return 0;
+}
+
+static void
+si_dealloc(PyObject *self)
+{
+    PyObject_GC_UnTrack(self);
+    si_clear(self);
+    Py_TYPE(self)->tp_free(self);
+}
+
+static int
+si_init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    ShallowImmutableObject *obj = (ShallowImmutableObject *)self;
+    PyObject *value = Py_None;
+    if (!PyArg_ParseTuple(args, "|O", &value))
+        return -1;
+    Py_XSETREF(obj->value, Py_NewRef(value));
+    return 0;
+}
+
+static PyTypeObject ShallowImmutable_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "_test_reachable.ShallowImmutable",
+    .tp_basicsize = sizeof(ShallowImmutableObject),
+    .tp_dealloc = si_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_IMMUTABLETYPE,
+    .tp_doc = "C-level type registered as shallow immutable.",
+    .tp_traverse = si_traverse,
+    .tp_clear = si_clear,
+    .tp_init = si_init,
+    .tp_alloc = PyType_GenericAlloc,
+    .tp_new = PyType_GenericNew,
+    .tp_free = PyObject_GC_Del,
+    .tp_reachable = si_reachable,
+};
+
 static int
 _test_reachable_exec(PyObject *module)
 {
@@ -193,6 +264,15 @@ _test_reachable_exec(PyObject *module)
     if (PyModule_AddType(module, &HasReachable_Type) != 0)
         return -1;
     if (_PyImmutability_RegisterFreezable(&HasReachable_Type) < 0)
+        return -1;
+
+    if (PyType_Ready(&ShallowImmutable_Type) < 0)
+        return -1;
+    if (PyModule_AddType(module, &ShallowImmutable_Type) != 0)
+        return -1;
+    if (_PyImmutability_RegisterFreezable(&ShallowImmutable_Type) < 0)
+        return -1;
+    if (_PyImmutability_RegisterShallowImmutable(&ShallowImmutable_Type) < 0)
         return -1;
 
     return 0;

--- a/Modules/clinic/_immutablemodule.c.h
+++ b/Modules/clinic/_immutablemodule.c.h
@@ -24,8 +24,11 @@ PyDoc_STRVAR(_immutable_isfrozen__doc__,
 "isfrozen($module, obj, /)\n"
 "--\n"
 "\n"
-"Check if an object is frozen.");
+"Check if an object is frozen (or can be viewed as immutable).\n"
+"\n"
+"If the object graph can be viewed as immutable, it will be frozen as a\n"
+"side effect and True is returned.");
 
 #define _IMMUTABLE_ISFROZEN_METHODDEF    \
     {"isfrozen", (PyCFunction)_immutable_isfrozen, METH_O, _immutable_isfrozen__doc__},
-/*[clinic end generated code: output=95f703fa7ad82910 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b08aeb9c23cc30c8 input=a9049054013a1b77]*/

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6985,7 +6985,13 @@ type_reachable(PyObject *self, visitproc visit, void *arg)
 
     Py_VISIT(_PyObject_CAST(Py_TYPE(self)));
 
-    Py_VISIT(lookup_tp_dict(type));
+    // Use tp_dict directly rather than lookup_tp_dict().
+    // For static builtin types, tp_dict is NULL here (the real dict is
+    // stored in per-interpreter state). This means freeze/implicit-immutability
+    // checks won't traverse into the type's method dict for builtins,
+    // which is the desired behavior — those dicts are structural internals
+    // of immutable types.
+    Py_VISIT(type->tp_dict);
     Py_VISIT(type->tp_cache);
     Py_VISIT(lookup_tp_mro(type));
     Py_VISIT(lookup_tp_bases(type));

--- a/Python/immutability.c
+++ b/Python/immutability.c
@@ -157,6 +157,40 @@ int init_state(struct _Py_immutability_state *state)
         return -1;
     }
 
+    state->shallow_immutable_types = _Py_hashtable_new(
+        _Py_hashtable_hash_ptr,
+        _Py_hashtable_compare_direct);
+    if(state->shallow_immutable_types == NULL){
+        return -1;
+    }
+
+    // Register built-in shallow immutable types.
+    // These types produce objects that are individually immutable
+    // but may reference other objects (e.g. tuple elements).
+    PyTypeObject *shallow_types[] = {
+        &PyTuple_Type,
+        &PyFrozenSet_Type,
+        &PyCode_Type,
+        &PyRange_Type,
+        &PyBytes_Type,
+        &PyUnicode_Type,
+        &PyLong_Type,
+        &PyFloat_Type,
+        &PyComplex_Type,
+        &PyBool_Type,
+        &_PyNone_Type,
+        &PyEllipsis_Type,
+        &_PyNotImplemented_Type,
+        &PyCFunction_Type,
+        NULL
+    };
+    for (int i = 0; shallow_types[i] != NULL; i++) {
+        if (_Py_hashtable_set(state->shallow_immutable_types,
+                              shallow_types[i], (void *)1) < 0) {
+            return -1;
+        }
+    }
+
     return 0;
 }
 
@@ -1143,41 +1177,7 @@ static int freeze_visit(PyObject* obj, void* freeze_state_untyped)
     return 0;
 }
 
-// NEEDED FOR future PR that handles shallow immutable correctly.
-// static int is_shallow_immutable(PyObject* obj)
-// {
-//     if (obj == NULL)
-//         return 0;
-//     if (Py_IS_TYPE(obj, &PyBool_Type) ||
-//         Py_IS_TYPE(obj, &_PyNone_Type) ||
-//         Py_IS_TYPE(obj, &PyLong_Type) ||
-//         Py_IS_TYPE(obj, &PyFloat_Type) ||
-//         Py_IS_TYPE(obj, &PyComplex_Type) ||
-//         Py_IS_TYPE(obj, &PyBytes_Type) ||
-//         Py_IS_TYPE(obj, &PyUnicode_Type) ||
-//         Py_IS_TYPE(obj, &PyTuple_Type) ||
-//         Py_IS_TYPE(obj, &PyFrozenSet_Type) ||
-//         Py_IS_TYPE(obj, &PyRange_Type) ||
-//         Py_IS_TYPE(obj, &PyCode_Type) ||
-//         Py_IS_TYPE(obj, &PyCFunction_Type) ||
-//         Py_IS_TYPE(obj, &PyCMethod_Type)
-//     ) {
-//         return 1;
-//     }
 
-//     // Types may be immutable, check flag.
-//     if (PyType_Check(obj))
-//     {
-//         PyTypeObject* type = (PyTypeObject*)obj;
-//         // Assume immutable types are safe to freeze.
-//         if (type->tp_flags & Py_TPFLAGS_IMMUTABLETYPE) {
-//             return 1;
-//         }
-//     }
-
-//     // TODO: Add user defined shallow immutable property
-//     return 0;
-// }
 
 static bool
 is_freezable_builtin(PyTypeObject *type)
@@ -1301,6 +1301,195 @@ int _PyImmutability_RegisterFreezable(PyTypeObject* tp)
     result = PySet_Add(state->freezable_types, ref);
     Py_DECREF(ref);
     return result;
+}
+
+static int
+is_shallow_immutable_type(struct _Py_immutability_state *state, PyTypeObject *tp)
+{
+    return _Py_hashtable_get(state->shallow_immutable_types, (void *)tp) != NULL;
+}
+
+int _PyImmutability_RegisterShallowImmutable(PyTypeObject* tp)
+{
+    struct _Py_immutability_state *state = get_immutable_state();
+    if (state == NULL) {
+        return -1;
+    }
+
+    // Idempotent — already registered is fine.
+    if (is_shallow_immutable_type(state, tp)) {
+        return 0;
+    }
+
+    if (_Py_hashtable_set(state->shallow_immutable_types,
+                          (void *)tp, (void *)1) < 0) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    return 0;
+}
+
+// Check if a specific object is shallow immutable.
+// (a) Its type is registered as shallow immutable (e.g. tuple instances,
+//     float instances), OR
+// (b) It is itself a type object with Py_TPFLAGS_IMMUTABLETYPE set
+//     (e.g. the float type object — but not a mutable heap type).
+static int
+is_shallow_immutable(struct _Py_immutability_state *state, PyObject *obj)
+{
+    if (is_shallow_immutable_type(state, Py_TYPE(obj))) {
+        return 1;
+    }
+    if (PyType_Check(obj)) {
+        PyTypeObject *tp = (PyTypeObject *)obj;
+        if (tp->tp_flags & Py_TPFLAGS_IMMUTABLETYPE) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+struct ImplicitCheckState {
+    _Py_hashtable_t *visited;
+    struct _Py_immutability_state *imm_state;
+    PyObject *worklist;  // PyListObject used as a stack
+};
+
+// Visitor callback that adds objects to the worklist for iterative processing.
+// Returns 0 if the object can be viewed as immutable and was added to the
+// worklist, 1 if a mutable object was found, -1 on error.
+static int
+can_view_as_immutable_visit(PyObject *obj, void *arg)
+{
+    struct ImplicitCheckState *state = (struct ImplicitCheckState *)arg;
+    if (obj == NULL) {
+        return 0;
+    }
+
+    // Already visited — skip.
+    if (_Py_hashtable_get(state->visited, obj) != NULL) {
+        return 0;
+    }
+
+    // Already frozen — skip.
+    if (_Py_IsImmutable(obj)) {
+        return 0;
+    }
+
+    // Check if the object can be viewed as immutable.
+    if (!is_shallow_immutable(state->imm_state, obj)) {
+        // Found a mutable object — graph cannot be viewed as immutable.
+        return 1;
+    }
+
+    // Mark visited.
+    if (_Py_hashtable_set(state->visited, obj, (void *)1) < 0) {
+        return -1;
+    }
+
+    // Add to worklist for traversal of referents.
+    if (PyList_Append(state->worklist, obj) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int _PyImmutability_CanViewAsImmutable(PyObject *obj)
+{
+    // Check if the object graph rooted at obj can be viewed as immutable.
+    // An object graph can be viewed as immutable if every reachable object
+    // is either already frozen, or is shallow immutable (its own state
+    // cannot be mutated, though it may reference other objects).
+    //
+    // If the graph can be viewed as immutable, it is frozen (to set up
+    // proper refcount management) and 1 is returned.
+    // Returns 0 if the graph cannot be viewed as immutable, -1 on error.
+
+    // Already frozen — trivially yes.
+    if (_Py_IsImmutable(obj)) {
+        return 1;
+    }
+
+    struct _Py_immutability_state *imm_state = get_immutable_state();
+    if (imm_state == NULL) {
+        return -1;
+    }
+
+    // The root must itself be shallow immutable to be viewed as immutable.
+    if (!is_shallow_immutable(imm_state, obj))
+    {
+        return 0;
+    }
+
+    struct ImplicitCheckState state;
+    state.imm_state = imm_state;
+    state.visited = _Py_hashtable_new(
+        _Py_hashtable_hash_ptr,
+        _Py_hashtable_compare_direct);
+    if (state.visited == NULL) {
+        PyErr_NoMemory();
+        return -1;
+    }
+
+    state.worklist = PyList_New(0);
+    if (state.worklist == NULL) {
+        _Py_hashtable_destroy(state.visited);
+        return -1;
+    }
+
+    // Mark root visited and seed the worklist.
+    if (_Py_hashtable_set(state.visited, obj, (void *)1) < 0) {
+        _Py_hashtable_destroy(state.visited);
+        Py_DECREF(state.worklist);
+        PyErr_NoMemory();
+        return -1;
+    }
+    if (PyList_Append(state.worklist, obj) < 0) {
+        _Py_hashtable_destroy(state.visited);
+        Py_DECREF(state.worklist);
+        return -1;
+    }
+
+    // Iterative DFS: pop from worklist, traverse referents.
+    int result = 0;
+    while (PyList_GET_SIZE(state.worklist) > 0) {
+        PyObject *item = PyList_GET_ITEM(
+            state.worklist, PyList_GET_SIZE(state.worklist) - 1);
+        Py_INCREF(item);
+        if (PyList_SetSlice(state.worklist,
+                            PyList_GET_SIZE(state.worklist) - 1,
+                            PyList_GET_SIZE(state.worklist), NULL) < 0) {
+            Py_DECREF(item);
+            result = -1;
+            break;
+        }
+
+        traverseproc reachable = get_reachable_proc(Py_TYPE(item));
+        result = reachable(item, can_view_as_immutable_visit, &state);
+        Py_DECREF(item);
+        if (result != 0) {
+            break;
+        }
+    }
+
+    _Py_hashtable_destroy(state.visited);
+    Py_DECREF(state.worklist);
+
+    if (result < 0) {
+        return -1;
+    }
+    if (result > 0) {
+        return 0;
+    }
+
+    // The graph can be viewed as immutable. Freeze to set up proper
+    // refcount management.
+    if (_PyImmutability_Freeze(obj) < 0) {
+        return -1;
+    }
+
+    return 1;
 }
 
 // Perform a decref on an immutable object

--- a/Python/immutability.c
+++ b/Python/immutability.c
@@ -1388,7 +1388,7 @@ can_view_as_immutable_visit(PyObject *obj, void *arg)
     }
 
     // Add to worklist for traversal of referents.
-    if (PyList_Append(state->worklist, obj) < 0) {
+    if (push(state->worklist, obj) < 0) {
         return -1;
     }
 
@@ -1445,7 +1445,7 @@ int _PyImmutability_CanViewAsImmutable(PyObject *obj)
         PyErr_NoMemory();
         return -1;
     }
-    if (PyList_Append(state.worklist, obj) < 0) {
+    if (push(state.worklist, obj) < 0) {
         _Py_hashtable_destroy(state.visited);
         Py_DECREF(state.worklist);
         return -1;
@@ -1454,20 +1454,9 @@ int _PyImmutability_CanViewAsImmutable(PyObject *obj)
     // Iterative DFS: pop from worklist, traverse referents.
     int result = 0;
     while (PyList_GET_SIZE(state.worklist) > 0) {
-        PyObject *item = PyList_GET_ITEM(
-            state.worklist, PyList_GET_SIZE(state.worklist) - 1);
-        Py_INCREF(item);
-        if (PyList_SetSlice(state.worklist,
-                            PyList_GET_SIZE(state.worklist) - 1,
-                            PyList_GET_SIZE(state.worklist), NULL) < 0) {
-            Py_DECREF(item);
-            result = -1;
-            break;
-        }
-
+        PyObject *item = pop(state.worklist);
         traverseproc reachable = get_reachable_proc(Py_TYPE(item));
         result = reachable(item, can_view_as_immutable_visit, &state);
-        Py_DECREF(item);
         if (result != 0) {
             break;
         }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -800,6 +800,10 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
         _Py_hashtable_destroy(interp->immutability.warned_types);
         interp->immutability.warned_types = NULL;
     }
+    if (interp->immutability.shallow_immutable_types != NULL) {
+        _Py_hashtable_destroy(interp->immutability.shallow_immutable_types);
+        interp->immutability.shallow_immutable_types = NULL;
+    }
 #ifdef Py_DEBUG
     Py_CLEAR(interp->immutability.traceback_func);
 #endif


### PR DESCRIPTION
Extend the freeze infrastructure with the ability to determine whether an object graph can be viewed as immutable without requiring an explicit freeze call. An object graph can be viewed as immutable if every reachable object is either already frozen or is "shallow immutable" (its own state cannot be mutated, but it may reference other objects).

If the graph can be viewed as immutable, it is frozen to set up proper refcount management, and isfrozen() returns True.

Key changes:

- Add _PyImmutability_CanViewAsImmutable() C API that walks the object graph using an iterative DFS (avoiding stack overflow on deep graphs) and checks that every reachable object is shallow immutable or already frozen. If the check passes, the graph is frozen via the existing _PyImmutability_Freeze().

- Add _PyImmutability_RegisterShallowImmutable() C API for extension modules to register types whose instances are individually immutable. Built-in types (tuple, frozenset, bytes, str, int, float, complex, bool, NoneType, etc.) are registered at init time.

- Immutable type objects (Py_TPFLAGS_IMMUTABLETYPE) are recognized as shallow immutable without explicit registration.

- Change type_reachable() to visit tp_dict directly rather than via lookup_tp_dict(). For static builtin types, tp_dict is NULL on the struct (stored in per-interpreter state), so the walk skips these internal dicts — avoiding false failures on type internals.

- Integrate the check into isfrozen(): it now returns True for objects that are explicitly frozen OR can be viewed as immutable (freezing as a side effect in the latter case).

- Add ShallowImmutable test type to _test_reachable C module to exercise RegisterShallowImmutable from C.

- Add 24 tests covering: tuples/frozensets of various types, mutable containers (correctly rejected), already-frozen objects, deeply nested structures (10,000 deep — verifies no stack overflow), and C-registered shallow immutable types.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
