### PR TITLE
Add SharedField type as shared escape hatch from freeze system

### DIFF
--- a/Lib/immutable.py
+++ b/Lib/immutable.py
@@ -18,6 +18,7 @@ FREEZABLE_NO = _c.FREEZABLE_NO
 FREEZABLE_EXPLICIT = _c.FREEZABLE_EXPLICIT
 FREEZABLE_PROXY = _c.FREEZABLE_PROXY
 InterpreterLocal = _c.InterpreterLocal
+SharedField = _c.SharedField
 
 # FIXME(immutable): For the longest time we used the name `isfrozen`
 # without the underscore. This keeps the function name for now, but
@@ -60,6 +61,7 @@ __all__ = [
     "FREEZABLE_EXPLICIT",
     "FREEZABLE_PROXY",
     "InterpreterLocal",
+    "SharedField",
     "freezable",
     "unfreezable",
     "explicitlyFreezable",

--- a/Lib/test/test_freeze/test_sharedfield.py
+++ b/Lib/test/test_freeze/test_sharedfield.py
@@ -1,0 +1,250 @@
+import os
+import unittest
+from immutable import freeze, is_frozen, SharedField, set_freezable, FREEZABLE_NO
+from test.support import import_helper
+
+
+class TestSharedFieldBasic(unittest.TestCase):
+    """Test basic SharedField with frozen values."""
+
+    def test_get_returns_initial(self):
+        sf = SharedField(42)
+        self.assertEqual(sf.get(), 42)
+
+    def test_set_frozen_value(self):
+        sf = SharedField(42)
+        sf.set(99)
+        self.assertEqual(sf.get(), 99)
+
+    def test_set_none(self):
+        sf = SharedField(42)
+        sf.set(None)
+        self.assertIsNone(sf.get())
+
+    def test_set_frozen_tuple(self):
+        sf = SharedField(())
+        sf.set((1, 2, 3))
+        self.assertEqual(sf.get(), (1, 2, 3))
+
+    def test_set_rejects_mutable(self):
+        sf = SharedField(42)
+        with self.assertRaises(TypeError):
+            sf.set([1, 2, 3])
+
+    def test_initial_value_is_frozen(self):
+        sf = SharedField(42)
+        self.assertTrue(is_frozen(sf.get()))
+
+    def test_get_consistent(self):
+        sf = SharedField("hello")
+        self.assertIs(sf.get(), sf.get())
+
+
+class TestSharedFieldSwap(unittest.TestCase):
+    """Test the unconditional swap operation."""
+
+    def test_swap_returns_old_value(self):
+        sf = SharedField(42)
+        old = sf.swap(99)
+        self.assertEqual(old, 42)
+        self.assertEqual(sf.get(), 99)
+
+    def test_swap_rejects_mutable(self):
+        sf = SharedField(42)
+        with self.assertRaises(TypeError):
+            sf.swap([])
+
+
+class TestSharedFieldCompareAndSwap(unittest.TestCase):
+    """Test the atomic compare-and-swap operation."""
+
+    def test_cas_succeeds(self):
+        sf = SharedField(42)
+        old = sf.get()
+        result = sf.compare_and_swap(old, 99)
+        self.assertTrue(result)
+        self.assertEqual(sf.get(), 99)
+
+    def test_cas_fails_wrong_expected(self):
+        sf = SharedField(42)
+        result = sf.compare_and_swap(0, 99)
+        self.assertFalse(result)
+        self.assertEqual(sf.get(), 42)
+
+    def test_cas_rejects_mutable_new(self):
+        sf = SharedField(42)
+        with self.assertRaises(TypeError):
+            sf.compare_and_swap(42, [])
+
+    def test_cas_wrong_arg_count(self):
+        sf = SharedField(42)
+        with self.assertRaises(TypeError):
+            sf.compare_and_swap(42)
+        with self.assertRaises(TypeError):
+            sf.compare_and_swap(1, 2, 3)
+
+
+class TestSharedFieldFreeze(unittest.TestCase):
+    """Test SharedField within frozen object graphs."""
+
+    def test_freeze_object_with_sharedfield(self):
+        class Container:
+            pass
+
+        c = Container()
+        c.field = SharedField(42)
+        freeze(c)
+        self.assertTrue(is_frozen(c))
+
+    def test_get_after_freeze(self):
+        class Container:
+            pass
+
+        c = Container()
+        c.field = SharedField(42)
+        freeze(c)
+        self.assertEqual(c.field.get(), 42)
+
+    def test_set_after_freeze(self):
+        class Container:
+            pass
+
+        c = Container()
+        c.field = SharedField(42)
+        freeze(c)
+        c.field.set(99)
+        self.assertEqual(c.field.get(), 99)
+
+    def test_swap_after_freeze(self):
+        class Container:
+            pass
+
+        c = Container()
+        c.field = SharedField(42)
+        freeze(c)
+        old = c.field.swap(99)
+        self.assertEqual(old, 42)
+        self.assertEqual(c.field.get(), 99)
+
+    def test_compare_and_swap_after_freeze(self):
+        class Container:
+            pass
+
+        c = Container()
+        c.field = SharedField(42)
+        freeze(c)
+        old = c.field.get()
+        self.assertTrue(c.field.compare_and_swap(old, 99))
+        self.assertEqual(c.field.get(), 99)
+
+    def test_sharedfield_itself_frozen(self):
+        sf = SharedField(42)
+        freeze(sf)
+        self.assertTrue(is_frozen(sf))
+
+    def test_set_rejects_mutable_after_freeze(self):
+        class Container:
+            pass
+
+        c = Container()
+        c.field = SharedField(42)
+        freeze(c)
+        with self.assertRaises(TypeError):
+            c.field.set([1, 2, 3])
+
+
+class TestSharedFieldErrors(unittest.TestCase):
+    """Test error cases."""
+
+    def test_no_args(self):
+        with self.assertRaises(TypeError):
+            SharedField()
+
+    def test_non_freezable_initial(self):
+        class NF:
+            pass
+        obj = NF()
+        set_freezable(obj, FREEZABLE_NO)
+        with self.assertRaises(TypeError):
+            SharedField(obj)
+
+    def test_multiple_independent_fields(self):
+        f1 = SharedField(1)
+        f2 = SharedField(2)
+        self.assertEqual(f1.get(), 1)
+        self.assertEqual(f2.get(), 2)
+        f1.set(10)
+        self.assertEqual(f1.get(), 10)
+        self.assertEqual(f2.get(), 2)
+
+
+class TestSharedFieldSubinterpreters(unittest.TestCase):
+    """Test that SharedField is shared across sub-interpreters."""
+
+    def setUp(self):
+        self._interpreters = import_helper.import_module('_interpreters')
+
+    def _run_in_subinterp(self, code, shared=None):
+        r, w = os.pipe()
+        wrapped = (
+            "import contextlib, os\n"
+            f"with open({w}, 'w', encoding='utf-8') as spipe:\n"
+            "    with contextlib.redirect_stdout(spipe):\n"
+        )
+        for line in code.splitlines():
+            wrapped += "        " + line + "\n"
+
+        interp = self._interpreters.create()
+        try:
+            self._interpreters.run_string(
+                interp, wrapped, shared=shared or {})
+        finally:
+            with os.fdopen(r, encoding='utf-8') as rpipe:
+                result = rpipe.read()
+            self._interpreters.destroy(interp)
+        return result
+
+    def test_shared_field_readable_in_subinterp(self):
+        """A frozen SharedField shared to a sub-interpreter should
+        be readable there."""
+        sf = SharedField(42)
+        freeze(sf)
+
+        output = self._run_in_subinterp(
+            "print(sf.get())\n",
+            shared={"sf": sf},
+        )
+        self.assertEqual(output.strip(), "42")
+
+    def test_shared_field_set_visible_across_interps(self):
+        """Setting a SharedField in a sub-interpreter should be
+        visible in the main interpreter (shared state)."""
+        sf = SharedField(0)
+        freeze(sf)
+
+        self._run_in_subinterp(
+            "sf.set(42)\n",
+            shared={"sf": sf},
+        )
+        # Unlike InterpreterLocal, SharedField is shared — change is visible
+        self.assertEqual(sf.get(), 42)
+
+    def test_shared_frozen_container_with_sharedfield(self):
+        """A frozen container with a SharedField should share
+        state across interpreters."""
+        class Container:
+            pass
+
+        c = Container()
+        c.counter = SharedField(0)
+        freeze(c)
+
+        self._run_in_subinterp(
+            "c.counter.set(99)\n",
+            shared={"c": c},
+        )
+        self.assertEqual(c.counter.get(), 99)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Modules/_immutablemodule.c
+++ b/Modules/_immutablemodule.c
@@ -23,6 +23,7 @@ typedef struct {
     PyObject *not_freezable_error_obj;
     PyObject *interpreter_locals;  // dict: InterpreterLocal -> value
     PyObject *interpreterlocal_type;  // heap type object
+    PyObject *sharedfield_type;  // heap type object
 } immutable_state;
 
 static struct PyModuleDef _immutablemodule;
@@ -42,6 +43,7 @@ immutable_clear(PyObject *module)
     Py_CLEAR(module_state->not_freezable_error_obj);
     Py_CLEAR(module_state->interpreter_locals);
     Py_CLEAR(module_state->interpreterlocal_type);
+    Py_CLEAR(module_state->sharedfield_type);
     return 0;
 }
 
@@ -52,6 +54,7 @@ immutable_traverse(PyObject *module, visitproc visit, void *arg)
     Py_VISIT(module_state->not_freezable_error_obj);
     Py_VISIT(module_state->interpreter_locals);
     Py_VISIT(module_state->interpreterlocal_type);
+    Py_VISIT(module_state->sharedfield_type);
     return 0;
 }
 
@@ -172,7 +175,9 @@ interpreterlocal_lookup(PyInterpreterLocalObject *self)
     // Under free-threading (--disable-gil), multiple threads in the same
     // interpreter share this dict.  The critical section makes the
     // get-or-init compound operation atomic so the factory is called
-    // at most once per interpreter.  On GIL builds this is a no-op.
+    // at most once per interpreter.  On GIL builds this is a no-op,
+    // which is safe because InterpreterLocal storage is per-interpreter
+    // and each interpreter's GIL serializes its own threads.
     Py_BEGIN_CRITICAL_SECTION(locals);
     int ret = PyDict_GetItemRef(locals, (PyObject *)self, &val);
     if (ret == 0) {
@@ -307,6 +312,200 @@ static PyType_Spec interpreterlocal_spec = {
 };
 
 
+/*
+ * SharedField type
+ *
+ * A mutable field inside a frozen object that only holds frozen values.
+ * Because the stored value is always immutable, it can be safely shared
+ * across sub-interpreters.  All access is protected by a PyMutex to
+ * avoid TOCTOU races between reading the pointer and adjusting reference
+ * counts.  A PyMutex is used rather than Py_BEGIN_CRITICAL_SECTION
+ * because the latter is a no-op on GIL-enabled builds, but SharedField
+ * can be accessed concurrently from different sub-interpreters (each
+ * with its own GIL).
+ *
+ * Unlike InterpreterLocal, tp_reachable DOES visit the stored value
+ * (since it's frozen and part of the shared immutable graph).
+ */
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *value;   // Always frozen; guarded by lock
+    PyMutex lock;      // Protects value across sub-interpreters
+} PySharedFieldObject;
+
+static int
+sharedfield_check_frozen(PyObject *value)
+{
+    if (!_PyImmutability_CanViewAsImmutable(value)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "SharedField value must be frozen");
+        return -1;
+    }
+    return 0;
+}
+
+static PyObject *
+sharedfield_get(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    PySharedFieldObject *sf = (PySharedFieldObject *)self;
+    PyMutex_Lock(&sf->lock);
+    PyObject *val = Py_NewRef(sf->value);
+    PyMutex_Unlock(&sf->lock);
+    return val;
+}
+
+static PyObject *
+sharedfield_swap(PyObject *self, PyObject *new_value)
+{
+    if (sharedfield_check_frozen(new_value) < 0) {
+        return NULL;
+    }
+    PySharedFieldObject *sf = (PySharedFieldObject *)self;
+    Py_INCREF(new_value);
+    PyMutex_Lock(&sf->lock);
+    PyObject *old = sf->value;
+    sf->value = new_value;
+    PyMutex_Unlock(&sf->lock);
+    return old;  // caller owns the reference
+}
+
+static PyObject *
+sharedfield_set(PyObject *self, PyObject *new_value)
+{
+    PyObject *old = sharedfield_swap(self, new_value);
+    if (old == NULL) {
+        return NULL;
+    }
+    Py_DECREF(old);
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+sharedfield_compare_and_swap(PyObject *self, PyObject *const *args,
+                             Py_ssize_t nargs)
+{
+    if (nargs != 2) {
+        PyErr_SetString(PyExc_TypeError,
+                        "compare_and_swap() requires exactly 2 arguments"
+                        " (old, new)");
+        return NULL;
+    }
+    PyObject *expected = args[0];
+    PyObject *new_value = args[1];
+
+    if (sharedfield_check_frozen(new_value) < 0) {
+        return NULL;
+    }
+
+    PySharedFieldObject *sf = (PySharedFieldObject *)self;
+    int swapped;
+    PyObject *old = NULL;
+    Py_INCREF(new_value);
+    PyMutex_Lock(&sf->lock);
+    if (sf->value == expected) {
+        old = sf->value;
+        sf->value = new_value;
+        swapped = 1;
+    }
+    else {
+        swapped = 0;
+    }
+    PyMutex_Unlock(&sf->lock);
+    if (swapped) {
+        Py_DECREF(old);
+        Py_RETURN_TRUE;
+    }
+    Py_DECREF(new_value);
+    Py_RETURN_FALSE;
+}
+
+static int
+sharedfield_init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    static char *kwlist[] = {"value", NULL};
+    PyObject *initial = NULL;
+    PySharedFieldObject *sf = (PySharedFieldObject *)self;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &initial)) {
+        return -1;
+    }
+
+    if (_PyImmutability_Freeze(initial) < 0) {
+        return -1;
+    }
+
+    sf->value = Py_NewRef(initial);
+    return 0;
+}
+
+static void
+sharedfield_dealloc(PyObject *self)
+{
+    PySharedFieldObject *sf = (PySharedFieldObject *)self;
+    PyObject_GC_UnTrack(self);
+    Py_CLEAR(sf->value);
+    PyTypeObject *tp = Py_TYPE(self);
+    tp->tp_free(self);
+    Py_DECREF(tp);
+}
+
+static int
+sharedfield_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    PySharedFieldObject *sf = (PySharedFieldObject *)self;
+    Py_VISIT(Py_TYPE(self));
+    Py_VISIT(sf->value);
+    return 0;
+}
+
+static int
+sharedfield_reachable(PyObject *self, visitproc visit, void *arg)
+{
+    // Visit the type and the stored value.
+    // The value is always frozen, so it's safe to include in the freeze walk.
+    PySharedFieldObject *sf = (PySharedFieldObject *)self;
+    Py_VISIT(Py_TYPE(self));
+    Py_VISIT(sf->value);
+    return 0;
+}
+
+static PyMethodDef sharedfield_methods[] = {
+    {"get", sharedfield_get, METH_NOARGS,
+     "Return the current value."},
+    {"set", sharedfield_set, METH_O,
+     "Set a new value. The value must be frozen."},
+    {"swap", sharedfield_swap, METH_O,
+     "Replace the value and return the old value. The new value must be frozen."},
+    {"compare_and_swap",
+     _PyCFunction_CAST(sharedfield_compare_and_swap), METH_FASTCALL,
+     "compare_and_swap(old, new) -> bool.\n"
+     "If the current value is `old`, replace it with `new` and return True.\n"
+     "Otherwise return False. The new value must be frozen."},
+    {NULL, NULL}
+};
+
+static PyType_Slot sharedfield_slots[] = {
+    {Py_tp_dealloc, sharedfield_dealloc},
+    {Py_tp_init, sharedfield_init},
+    {Py_tp_methods, sharedfield_methods},
+    {Py_tp_traverse, sharedfield_traverse},
+    {Py_tp_reachable, sharedfield_reachable},
+    {Py_tp_new, PyType_GenericNew},
+    {Py_tp_alloc, PyType_GenericAlloc},
+    {Py_tp_free, PyObject_GC_Del},
+    {0, NULL},
+};
+
+static PyType_Spec sharedfield_spec = {
+    .name = "_immutable.SharedField",
+    .basicsize = sizeof(PySharedFieldObject),
+    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE |
+              Py_TPFLAGS_HAVE_GC),
+    .slots = sharedfield_slots,
+};
+
+
 static PyType_Slot not_freezable_error_slots[] = {
     {0, NULL},
 };
@@ -390,6 +589,21 @@ immutable_exec(PyObject *module) {
     }
     if (_PyImmutability_SetFreezable(
             module_state->interpreter_locals, _Py_FREEZABLE_NO) < 0) {
+        return -1;
+    }
+
+    /* Create SharedField heap type */
+    module_state->sharedfield_type = PyType_FromModuleAndSpec(
+        module, &sharedfield_spec, NULL);
+    if (module_state->sharedfield_type == NULL) {
+        return -1;
+    }
+    if (PyModule_AddType(module,
+                         (PyTypeObject *)module_state->sharedfield_type) != 0) {
+        return -1;
+    }
+    if (_PyImmutability_SetFreezable(
+            module_state->sharedfield_type, _Py_FREEZABLE_YES) < 0) {
         return -1;
     }
 

--- a/Modules/_immutablemodule.c
+++ b/Modules/_immutablemodule.c
@@ -450,7 +450,6 @@ sharedfield_dealloc(PyObject *self)
 static int
 sharedfield_traverse(PyObject *self, visitproc visit, void *arg)
 {
-    PySharedFieldObject *sf = (PySharedFieldObject *)self;
     Py_VISIT(Py_TYPE(self));
     return 0;
 }
@@ -458,9 +457,6 @@ sharedfield_traverse(PyObject *self, visitproc visit, void *arg)
 static int
 sharedfield_reachable(PyObject *self, visitproc visit, void *arg)
 {
-    // Visit the type and the stored value.
-    // The value is always frozen, so it's safe to include in the freeze walk.
-    PySharedFieldObject *sf = (PySharedFieldObject *)self;
     Py_VISIT(Py_TYPE(self));
     return 0;
 }

--- a/Modules/_immutablemodule.c
+++ b/Modules/_immutablemodule.c
@@ -455,7 +455,6 @@ sharedfield_traverse(PyObject *self, visitproc visit, void *arg)
 {
     PySharedFieldObject *sf = (PySharedFieldObject *)self;
     Py_VISIT(Py_TYPE(self));
-    Py_VISIT(sf->value);
     return 0;
 }
 
@@ -466,7 +465,6 @@ sharedfield_reachable(PyObject *self, visitproc visit, void *arg)
     // The value is always frozen, so it's safe to include in the freeze walk.
     PySharedFieldObject *sf = (PySharedFieldObject *)self;
     Py_VISIT(Py_TYPE(self));
-    Py_VISIT(sf->value);
     return 0;
 }
 

--- a/Modules/_immutablemodule.c
+++ b/Modules/_immutablemodule.c
@@ -323,9 +323,6 @@ static PyType_Spec interpreterlocal_spec = {
  * because the latter is a no-op on GIL-enabled builds, but SharedField
  * can be accessed concurrently from different sub-interpreters (each
  * with its own GIL).
- *
- * Unlike InterpreterLocal, tp_reachable DOES visit the stored value
- * (since it's frozen and part of the shared immutable graph).
  */
 
 typedef struct {


### PR DESCRIPTION
SharedField provides a mutable field inside a frozen object that only holds frozen values. Unlike InterpreterLocal (which gives each sub-interpreter its own independent value), SharedField is truly shared: writes from one sub-interpreter are visible to all others.

API:
  get()                    - read the current value
  set(val)                 - replace the value (must be frozen)
  swap(val)                - replace and return the old value (must be frozen)
  compare_and_swap(old, new) - CAS: replace only if current value is old

All operations are protected by a PyMutex embedded in the object. A PyMutex is used rather than Py_BEGIN_CRITICAL_SECTION because the latter is a no-op on GIL builds, but SharedField can be accessed concurrently from different sub-interpreters (each with its own GIL).

set() is implemented in terms of swap() to avoid duplication.

Files changed:
  Modules/_immutablemodule.c              - SharedField type implementation
  Lib/immutable.py                        - Re-export SharedField
  Lib/test/test_freeze/test_sharedfield.py - Tests including cross-interpreter
    sharing, CAS semantics, and frozen-value enforcement