### PR TITLE
Support frozen sys module in _bootstrap

### DIFF
--- a/Include/internal/pycore_immutability.h
+++ b/Include/internal/pycore_immutability.h
@@ -8,12 +8,10 @@ extern "C" {
 #  error "Py_BUILD_CORE must be defined to include this header"
 #endif
 
-typedef struct _Py_hashtable_t _Py_hashtable_t;
-
 struct _Py_immutability_state {
     int late_init_done;
-    _Py_hashtable_t *shallow_immutable_types;
-    _Py_hashtable_t *warned_types;
+    struct _Py_hashtable_t *shallow_immutable_types;
+    struct _Py_hashtable_t *warned_types;
     // With the pre-freeze hook it can happen that freeze calls are
     // nested. This is stack of the enclosing freeze states.
     struct FreezeState *freeze_stack;

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -44,9 +44,30 @@ def _wrap(new, old):
             setattr(new, replace, getattr(old, replace))
     new.__dict__.update(old.__dict__)
 
+def _module_type():
+    sys_type = type(sys)
+    if sys_type.__name__ == "module":
+        return sys_type
+
+    # The `sys` module is immutable, we need to get the module type
+    # another way...
+    mods = [_bootstrap_external, _thread, _warnings, _weakref]
+    for m in mods:
+        if type(m).__name__ == "module":
+            return type(m)
+
+    for m in sys.mut_modules.values():
+        if type(m).__name__ == "module":
+            return type(m)
+
+    # There are other ways to make this work, we can for example
+    # pass in the module type into a global variable in this script
+    # or store the module in a global. This is a bridge we can cross,
+    # when we get there.
+    raise Exception("sys and all other modules currently accessible are immutable, this is bad")
 
 def _new_module(name):
-    return type(sys)(name)
+    return _module_type()(name)
 
 
 # Module-level locking ########################################################
@@ -1527,7 +1548,7 @@ def _setup(sys_module, _imp_module):
     sys = sys_module
 
     # Set up the spec for existing builtin/frozen modules.
-    module_type = type(sys)
+    module_type = _module_type()
     for name, module in sys.modules.items():
         if isinstance(module, module_type):
             if name in sys.builtin_module_names:

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -1657,7 +1657,7 @@ PyTypeObject _PyImmModule_Type = {
     0,                                          /* tp_dictoffset */
     module___init__,                            /* tp_init */
     0,                                          /* tp_alloc */
-    .tp_new = NULL, /* Intentionally NULL since it should not be instanciated. */
+    .tp_new = NULL, /* Intentionally NULL since it should not be instantiated. */
     .tp_free = PyObject_GC_Del,                            /* tp_free */
     .tp_reachable = module_reachable,
 };

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1386,7 +1386,7 @@ PyModuleObject* _PyInterpreterState_GetModuleState(PyObject *mod) {
             if (modules_mod == mod) {
                 // The modules in `sys.modules` is this frozen mod but there is
                 // no mutable state in `sys.mut_modules`, probably because it was
-                // unimported? Either way: 
+                // unimported? Either way:
                 // Remove `mod` from `sys.modules` and trigger a reimport.
                 if (PyDict_DelItem(modules, self->md_name) < 0) {
                     Py_DECREF(modules_mod);

--- a/Tools/c-analyzer/cpython/globals-to-fix.tsv
+++ b/Tools/c-analyzer/cpython/globals-to-fix.tsv
@@ -3,6 +3,29 @@ filename	funcname	name	reason
 
 # These are all variables that we will be making non-global.
 
+###############################
+## Pyrona
+
+## ---------------
+## Safe
+
+Python/immutability.c	-	PostOrderMarker	-
+Python/immutability.c	-	EnsureVisitedMarker	-
+Objects/weakrefobject.c	-	_PyWeakref_Lock	-
+
+## ---------------
+## Lazy
+
+
+## ---------------
+## Tests
+
+Modules/_test_reachable.c	-	HasTraverseNoReachable_Type	-
+Modules/_test_reachable.c	-	NoTraverseNoReachable_Type	-
+Modules/_test_reachable.c	-	HasReachable_Type	-
+Modules/_test_reachable.c	-	ShallowImmutable_Type	-
+
+
 ##################################
 ## global objects to fix in core code
 


### PR DESCRIPTION
I sadly can't test this without freezing `sys` for all other tests, since `sys` seems to be the one module that can't be unimported to undo the freeze.

However, I manually tested it, and it works, this used to fail:

```
# Setup
from immutable import freeze
import sys
freeze(sys)

# This previously failed:
import random
```